### PR TITLE
Add gstack skill symlinks for workspace auto-discovery

### DIFF
--- a/.claude/skills/autoplan
+++ b/.claude/skills/autoplan
@@ -1,0 +1,1 @@
+gstack/autoplan

--- a/.claude/skills/benchmark
+++ b/.claude/skills/benchmark
@@ -1,0 +1,1 @@
+gstack/benchmark

--- a/.claude/skills/browse
+++ b/.claude/skills/browse
@@ -1,0 +1,1 @@
+gstack/browse

--- a/.claude/skills/canary
+++ b/.claude/skills/canary
@@ -1,0 +1,1 @@
+gstack/canary

--- a/.claude/skills/careful
+++ b/.claude/skills/careful
@@ -1,0 +1,1 @@
+gstack/careful

--- a/.claude/skills/checkpoint
+++ b/.claude/skills/checkpoint
@@ -1,0 +1,1 @@
+gstack/checkpoint

--- a/.claude/skills/codex
+++ b/.claude/skills/codex
@@ -1,0 +1,1 @@
+gstack/codex

--- a/.claude/skills/connect-chrome
+++ b/.claude/skills/connect-chrome
@@ -1,0 +1,1 @@
+gstack/connect-chrome

--- a/.claude/skills/cso
+++ b/.claude/skills/cso
@@ -1,0 +1,1 @@
+gstack/cso

--- a/.claude/skills/design-consultation
+++ b/.claude/skills/design-consultation
@@ -1,0 +1,1 @@
+gstack/design-consultation

--- a/.claude/skills/design-html
+++ b/.claude/skills/design-html
@@ -1,0 +1,1 @@
+gstack/design-html

--- a/.claude/skills/design-review
+++ b/.claude/skills/design-review
@@ -1,0 +1,1 @@
+gstack/design-review

--- a/.claude/skills/design-shotgun
+++ b/.claude/skills/design-shotgun
@@ -1,0 +1,1 @@
+gstack/design-shotgun

--- a/.claude/skills/document-release
+++ b/.claude/skills/document-release
@@ -1,0 +1,1 @@
+gstack/document-release

--- a/.claude/skills/freeze
+++ b/.claude/skills/freeze
@@ -1,0 +1,1 @@
+gstack/freeze

--- a/.claude/skills/gstack-upgrade
+++ b/.claude/skills/gstack-upgrade
@@ -1,0 +1,1 @@
+gstack/gstack-upgrade

--- a/.claude/skills/guard
+++ b/.claude/skills/guard
@@ -1,0 +1,1 @@
+gstack/guard

--- a/.claude/skills/health
+++ b/.claude/skills/health
@@ -1,0 +1,1 @@
+gstack/health

--- a/.claude/skills/investigate
+++ b/.claude/skills/investigate
@@ -1,0 +1,1 @@
+gstack/investigate

--- a/.claude/skills/land-and-deploy
+++ b/.claude/skills/land-and-deploy
@@ -1,0 +1,1 @@
+gstack/land-and-deploy

--- a/.claude/skills/learn
+++ b/.claude/skills/learn
@@ -1,0 +1,1 @@
+gstack/learn

--- a/.claude/skills/office-hours
+++ b/.claude/skills/office-hours
@@ -1,0 +1,1 @@
+gstack/office-hours

--- a/.claude/skills/plan-ceo-review
+++ b/.claude/skills/plan-ceo-review
@@ -1,0 +1,1 @@
+gstack/plan-ceo-review

--- a/.claude/skills/plan-design-review
+++ b/.claude/skills/plan-design-review
@@ -1,0 +1,1 @@
+gstack/plan-design-review

--- a/.claude/skills/plan-eng-review
+++ b/.claude/skills/plan-eng-review
@@ -1,0 +1,1 @@
+gstack/plan-eng-review

--- a/.claude/skills/qa
+++ b/.claude/skills/qa
@@ -1,0 +1,1 @@
+gstack/qa

--- a/.claude/skills/qa-only
+++ b/.claude/skills/qa-only
@@ -1,0 +1,1 @@
+gstack/qa-only

--- a/.claude/skills/retro
+++ b/.claude/skills/retro
@@ -1,0 +1,1 @@
+gstack/retro

--- a/.claude/skills/review
+++ b/.claude/skills/review
@@ -1,0 +1,1 @@
+gstack/review

--- a/.claude/skills/setup-browser-cookies
+++ b/.claude/skills/setup-browser-cookies
@@ -1,0 +1,1 @@
+gstack/setup-browser-cookies

--- a/.claude/skills/setup-deploy
+++ b/.claude/skills/setup-deploy
@@ -1,0 +1,1 @@
+gstack/setup-deploy

--- a/.claude/skills/ship
+++ b/.claude/skills/ship
@@ -1,0 +1,1 @@
+gstack/ship

--- a/.claude/skills/unfreeze
+++ b/.claude/skills/unfreeze
@@ -1,0 +1,1 @@
+gstack/unfreeze


### PR DESCRIPTION
## Summary
Adds 33 symlinks in `.claude/skills/` pointing to vendored gstack skill directories so that `/ship`, `/qa`, `/review`, `/browse`, and all other gstack skills are automatically discoverable in every new Conductor workspace — no manual `./setup` step required.

## Related Issues
Relates to #1

## Type of Change
- [x] Feature (new capability)
- [ ] Bug fix (corrects an issue)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Data model change
- [x] CI/CD / Infrastructure
- [ ] Test

## Changes Made
- Ran `gstack/setup --local --no-prefix` to generate project-local symlinks
- Committed 33 symlinks (e.g. `.claude/skills/ship -> gstack/ship/`) so they're tracked in git
- Previously, gstack skills were only available via global install at `~/.codex/skills/` which pointed to a different repo, causing `/ship` and other gstack skills to not resolve in new workspaces

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Test coverage maintained or improved

## Documentation
- [ ] MD documentation updated
- [ ] DOCX generated
- [ ] Demo HTML updated
- [x] N/A - no doc changes needed

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] No new warnings introduced
- [ ] Linked to issue(s)
- [ ] Labels applied