### PR TITLE
Fix all 95 skill symlinks for Claude Code discovery

### DIFF
--- a/.claude/skills/autoplan/SKILL.md
+++ b/.claude/skills/autoplan/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/autoplan/SKILL.md
+../gstack/autoplan/SKILL.md

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/benchmark/SKILL.md
+../gstack/benchmark/SKILL.md

--- a/.claude/skills/browse/SKILL.md
+++ b/.claude/skills/browse/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/browse/SKILL.md
+../gstack/browse/SKILL.md

--- a/.claude/skills/canary/SKILL.md
+++ b/.claude/skills/canary/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/canary/SKILL.md
+../gstack/canary/SKILL.md

--- a/.claude/skills/careful/SKILL.md
+++ b/.claude/skills/careful/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/careful/SKILL.md
+../gstack/careful/SKILL.md

--- a/.claude/skills/checkpoint/SKILL.md
+++ b/.claude/skills/checkpoint/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/checkpoint/SKILL.md
+../gstack/checkpoint/SKILL.md

--- a/.claude/skills/claude-code-best-practices/SKILL.md
+++ b/.claude/skills/claude-code-best-practices/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/claude-code-best-practices/SKILL.md

--- a/.claude/skills/codex/SKILL.md
+++ b/.claude/skills/codex/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/codex/SKILL.md
+../gstack/codex/SKILL.md

--- a/.claude/skills/connect-chrome/SKILL.md
+++ b/.claude/skills/connect-chrome/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/connect-chrome/SKILL.md
+../gstack/connect-chrome/SKILL.md

--- a/.claude/skills/cso/SKILL.md
+++ b/.claude/skills/cso/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/cso/SKILL.md
+../gstack/cso/SKILL.md

--- a/.claude/skills/csv-output/SKILL.md
+++ b/.claude/skills/csv-output/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/csv-output/SKILL.md

--- a/.claude/skills/deploy-prep/SKILL.md
+++ b/.claude/skills/deploy-prep/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/deploy-prep/SKILL.md

--- a/.claude/skills/design-consultation/SKILL.md
+++ b/.claude/skills/design-consultation/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/design-consultation/SKILL.md
+../gstack/design-consultation/SKILL.md

--- a/.claude/skills/design-html/SKILL.md
+++ b/.claude/skills/design-html/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/design-html/SKILL.md
+../gstack/design-html/SKILL.md

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/design-review/SKILL.md
+../gstack/design-review/SKILL.md

--- a/.claude/skills/design-shotgun/SKILL.md
+++ b/.claude/skills/design-shotgun/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/design-shotgun/SKILL.md
+../gstack/design-shotgun/SKILL.md

--- a/.claude/skills/document-release/SKILL.md
+++ b/.claude/skills/document-release/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/document-release/SKILL.md
+../gstack/document-release/SKILL.md

--- a/.claude/skills/freeze/SKILL.md
+++ b/.claude/skills/freeze/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/freeze/SKILL.md
+../gstack/freeze/SKILL.md

--- a/.claude/skills/gstack-upgrade/SKILL.md
+++ b/.claude/skills/gstack-upgrade/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/gstack-upgrade/SKILL.md
+../gstack/gstack-upgrade/SKILL.md

--- a/.claude/skills/guard/SKILL.md
+++ b/.claude/skills/guard/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/guard/SKILL.md
+../gstack/guard/SKILL.md

--- a/.claude/skills/health/SKILL.md
+++ b/.claude/skills/health/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/health/SKILL.md
+../gstack/health/SKILL.md

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/investigate/SKILL.md
+../gstack/investigate/SKILL.md

--- a/.claude/skills/land-and-deploy/SKILL.md
+++ b/.claude/skills/land-and-deploy/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/land-and-deploy/SKILL.md
+../gstack/land-and-deploy/SKILL.md

--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/learn/SKILL.md
+../gstack/learn/SKILL.md

--- a/.claude/skills/office-hours/SKILL.md
+++ b/.claude/skills/office-hours/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/office-hours/SKILL.md
+../gstack/office-hours/SKILL.md

--- a/.claude/skills/ohfy-configure-expert/SKILL.md
+++ b/.claude/skills/ohfy-configure-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-configure-expert/SKILL.md

--- a/.claude/skills/ohfy-core-expert/SKILL.md
+++ b/.claude/skills/ohfy-core-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-core-expert/SKILL.md

--- a/.claude/skills/ohfy-data-model-expert/SKILL.md
+++ b/.claude/skills/ohfy-data-model-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-data-model-expert/SKILL.md

--- a/.claude/skills/ohfy-ecom-expert/SKILL.md
+++ b/.claude/skills/ohfy-ecom-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-ecom-expert/SKILL.md

--- a/.claude/skills/ohfy-edi-expert/SKILL.md
+++ b/.claude/skills/ohfy-edi-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-edi-expert/SKILL.md

--- a/.claude/skills/ohfy-oms-expert/SKILL.md
+++ b/.claude/skills/ohfy-oms-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-oms-expert/SKILL.md

--- a/.claude/skills/ohfy-payments-expert/SKILL.md
+++ b/.claude/skills/ohfy-payments-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-payments-expert/SKILL.md

--- a/.claude/skills/ohfy-platform-expert/SKILL.md
+++ b/.claude/skills/ohfy-platform-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-platform-expert/SKILL.md

--- a/.claude/skills/ohfy-rex-expert/SKILL.md
+++ b/.claude/skills/ohfy-rex-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-rex-expert/SKILL.md

--- a/.claude/skills/ohfy-transformation-settings/SKILL.md
+++ b/.claude/skills/ohfy-transformation-settings/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-transformation-settings/SKILL.md

--- a/.claude/skills/ohfy-wms-expert/SKILL.md
+++ b/.claude/skills/ohfy-wms-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ohfy-wms-expert/SKILL.md

--- a/.claude/skills/org-connect/SKILL.md
+++ b/.claude/skills/org-connect/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/org-connect/SKILL.md

--- a/.claude/skills/plan-ceo-review/SKILL.md
+++ b/.claude/skills/plan-ceo-review/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/plan-ceo-review/SKILL.md
+../gstack/plan-ceo-review/SKILL.md

--- a/.claude/skills/plan-design-review/SKILL.md
+++ b/.claude/skills/plan-design-review/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/plan-design-review/SKILL.md
+../gstack/plan-design-review/SKILL.md

--- a/.claude/skills/plan-eng-review/SKILL.md
+++ b/.claude/skills/plan-eng-review/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/plan-eng-review/SKILL.md
+../gstack/plan-eng-review/SKILL.md

--- a/.claude/skills/qa-only/SKILL.md
+++ b/.claude/skills/qa-only/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/qa-only/SKILL.md
+../gstack/qa-only/SKILL.md

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/qa/SKILL.md
+../gstack/qa/SKILL.md

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/retro/SKILL.md
+../gstack/retro/SKILL.md

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/review/SKILL.md
+../gstack/review/SKILL.md

--- a/.claude/skills/salesforce-composite/SKILL.md
+++ b/.claude/skills/salesforce-composite/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/salesforce-composite/SKILL.md

--- a/.claude/skills/salesforce-field-object-creator/SKILL.md
+++ b/.claude/skills/salesforce-field-object-creator/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/salesforce-field-object-creator/SKILL.md

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/security/SKILL.md

--- a/.claude/skills/setup-browser-cookies/SKILL.md
+++ b/.claude/skills/setup-browser-cookies/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/setup-browser-cookies/SKILL.md
+../gstack/setup-browser-cookies/SKILL.md

--- a/.claude/skills/setup-deploy/SKILL.md
+++ b/.claude/skills/setup-deploy/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/setup-deploy/SKILL.md
+../gstack/setup-deploy/SKILL.md

--- a/.claude/skills/sf-ai-agentforce-observability/SKILL.md
+++ b/.claude/skills/sf-ai-agentforce-observability/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-ai-agentforce-observability/SKILL.md

--- a/.claude/skills/sf-ai-agentforce-persona/SKILL.md
+++ b/.claude/skills/sf-ai-agentforce-persona/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-ai-agentforce-persona/SKILL.md

--- a/.claude/skills/sf-ai-agentforce-testing/SKILL.md
+++ b/.claude/skills/sf-ai-agentforce-testing/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-ai-agentforce-testing/SKILL.md

--- a/.claude/skills/sf-ai-agentforce/SKILL.md
+++ b/.claude/skills/sf-ai-agentforce/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-ai-agentforce/SKILL.md

--- a/.claude/skills/sf-ai-agentscript/SKILL.md
+++ b/.claude/skills/sf-ai-agentscript/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-ai-agentscript/SKILL.md

--- a/.claude/skills/sf-apex/SKILL.md
+++ b/.claude/skills/sf-apex/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-apex/SKILL.md

--- a/.claude/skills/sf-connected-apps/SKILL.md
+++ b/.claude/skills/sf-connected-apps/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-connected-apps/SKILL.md

--- a/.claude/skills/sf-data/SKILL.md
+++ b/.claude/skills/sf-data/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-data/SKILL.md

--- a/.claude/skills/sf-datacloud-act/SKILL.md
+++ b/.claude/skills/sf-datacloud-act/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-datacloud-act/SKILL.md

--- a/.claude/skills/sf-datacloud-connect/SKILL.md
+++ b/.claude/skills/sf-datacloud-connect/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-datacloud-connect/SKILL.md

--- a/.claude/skills/sf-datacloud-harmonize/SKILL.md
+++ b/.claude/skills/sf-datacloud-harmonize/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-datacloud-harmonize/SKILL.md

--- a/.claude/skills/sf-datacloud-prepare/SKILL.md
+++ b/.claude/skills/sf-datacloud-prepare/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-datacloud-prepare/SKILL.md

--- a/.claude/skills/sf-datacloud-retrieve/SKILL.md
+++ b/.claude/skills/sf-datacloud-retrieve/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-datacloud-retrieve/SKILL.md

--- a/.claude/skills/sf-datacloud-segment/SKILL.md
+++ b/.claude/skills/sf-datacloud-segment/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-datacloud-segment/SKILL.md

--- a/.claude/skills/sf-datacloud/SKILL.md
+++ b/.claude/skills/sf-datacloud/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-datacloud/SKILL.md

--- a/.claude/skills/sf-debug/SKILL.md
+++ b/.claude/skills/sf-debug/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-debug/SKILL.md

--- a/.claude/skills/sf-deploy/SKILL.md
+++ b/.claude/skills/sf-deploy/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-deploy/SKILL.md

--- a/.claude/skills/sf-diagram-mermaid/SKILL.md
+++ b/.claude/skills/sf-diagram-mermaid/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-diagram-mermaid/SKILL.md

--- a/.claude/skills/sf-diagram-nanobananapro/SKILL.md
+++ b/.claude/skills/sf-diagram-nanobananapro/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-diagram-nanobananapro/SKILL.md

--- a/.claude/skills/sf-docs/SKILL.md
+++ b/.claude/skills/sf-docs/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-docs/SKILL.md

--- a/.claude/skills/sf-flow/SKILL.md
+++ b/.claude/skills/sf-flow/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-flow/SKILL.md

--- a/.claude/skills/sf-industry-commoncore-callable-apex/SKILL.md
+++ b/.claude/skills/sf-industry-commoncore-callable-apex/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-industry-commoncore-callable-apex/SKILL.md

--- a/.claude/skills/sf-industry-commoncore-datamapper/SKILL.md
+++ b/.claude/skills/sf-industry-commoncore-datamapper/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-industry-commoncore-datamapper/SKILL.md

--- a/.claude/skills/sf-industry-commoncore-flexcard/SKILL.md
+++ b/.claude/skills/sf-industry-commoncore-flexcard/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-industry-commoncore-flexcard/SKILL.md

--- a/.claude/skills/sf-industry-commoncore-integration-procedure/SKILL.md
+++ b/.claude/skills/sf-industry-commoncore-integration-procedure/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-industry-commoncore-integration-procedure/SKILL.md

--- a/.claude/skills/sf-industry-commoncore-omniscript/SKILL.md
+++ b/.claude/skills/sf-industry-commoncore-omniscript/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-industry-commoncore-omniscript/SKILL.md

--- a/.claude/skills/sf-industry-commoncore-omnistudio-analyze/SKILL.md
+++ b/.claude/skills/sf-industry-commoncore-omnistudio-analyze/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-industry-commoncore-omnistudio-analyze/SKILL.md

--- a/.claude/skills/sf-integration/SKILL.md
+++ b/.claude/skills/sf-integration/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-integration/SKILL.md

--- a/.claude/skills/sf-lwc/SKILL.md
+++ b/.claude/skills/sf-lwc/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-lwc/SKILL.md

--- a/.claude/skills/sf-metadata/SKILL.md
+++ b/.claude/skills/sf-metadata/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-metadata/SKILL.md

--- a/.claude/skills/sf-permissions/SKILL.md
+++ b/.claude/skills/sf-permissions/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-permissions/SKILL.md

--- a/.claude/skills/sf-soql/SKILL.md
+++ b/.claude/skills/sf-soql/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-soql/SKILL.md

--- a/.claude/skills/sf-testing/SKILL.md
+++ b/.claude/skills/sf-testing/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/sf-testing/SKILL.md

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/ship/SKILL.md
+../gstack/ship/SKILL.md

--- a/.claude/skills/test-script/SKILL.md
+++ b/.claude/skills/test-script/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/test-script/SKILL.md

--- a/.claude/skills/tray-diagrams/SKILL.md
+++ b/.claude/skills/tray-diagrams/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/tray-diagrams/SKILL.md

--- a/.claude/skills/tray-embedded-customjs/SKILL.md
+++ b/.claude/skills/tray-embedded-customjs/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/tray-embedded-customjs/SKILL.md

--- a/.claude/skills/tray-errors/SKILL.md
+++ b/.claude/skills/tray-errors/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/tray-errors/SKILL.md

--- a/.claude/skills/tray-expert/SKILL.md
+++ b/.claude/skills/tray-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/tray-expert/SKILL.md

--- a/.claude/skills/tray-insights/SKILL.md
+++ b/.claude/skills/tray-insights/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/tray-insights/SKILL.md

--- a/.claude/skills/tray-script-generator/SKILL.md
+++ b/.claude/skills/tray-script-generator/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/tray-script-generator/SKILL.md

--- a/.claude/skills/ukg-api-debug/SKILL.md
+++ b/.claude/skills/ukg-api-debug/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ukg-api-debug/SKILL.md

--- a/.claude/skills/ukg-expert/SKILL.md
+++ b/.claude/skills/ukg-expert/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ukg-expert/SKILL.md

--- a/.claude/skills/ukg-field-mapper/SKILL.md
+++ b/.claude/skills/ukg-field-mapper/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/ukg-field-mapper/SKILL.md

--- a/.claude/skills/unfreeze/SKILL.md
+++ b/.claude/skills/unfreeze/SKILL.md
@@ -1,1 +1,1 @@
-/Users/danielzeder/conductor/workspaces/daniels-ohanafy/calgary-v1/.claude/skills/gstack/unfreeze/SKILL.md
+../gstack/unfreeze/SKILL.md


### PR DESCRIPTION
## Summary
All skills in the repo were invisible to Claude Code due to broken or missing symlinks in `.claude/skills/`. This PR fixes all 95 skill symlinks so they're properly discoverable.

## Related Issues
Relates to #2

## Type of Change
- [ ] Feature (new capability)
- [x] Bug fix (corrects an issue)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Data model change
- [ ] CI/CD / Infrastructure
- [ ] Test

## Changes Made
- Fixed 33 broken gstack skill symlinks (browse, qa, ship, review, etc.) that pointed to non-existent `calgary-v1` workspace — repointed to local `gstack/` directory
- Added 61 new symlinks for domain skills (sf-*, ohfy-*, tray-*, ukg-*, etc.) that existed in `skills/` but had no `.claude/skills/` entries

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Test coverage maintained or improved

Verified zero broken symlinks and 95 total discoverable skills after changes.

## Documentation
- [x] N/A - no doc changes needed

## Time Tracking
| Metric | Value |
|--------|-------|
| Human Estimate (hrs) | 1 |
| AI Actual (hrs) | 0.1 |
| Time Saved (%) | 90% |

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Linked to issue(s)
- [ ] Labels applied