### PR TITLE
fix: resolve two consistently failing GitHub Actions

### DIFF
--- a/.github/workflows/check-sf-skills-update.yml
+++ b/.github/workflows/check-sf-skills-update.yml
@@ -76,7 +76,7 @@ jobs:
             fi
           done
 
-          # Write summary to a file to avoid shell injection via ${{ }} interpolation
+          # Write summary to a file to avoid shell injection via expression interpolation
           SUMMARY_FILE=$(mktemp)
           {
             echo "## Upstream sf-skills changes"

--- a/.github/workflows/security-agent.yml
+++ b/.github/workflows/security-agent.yml
@@ -12,7 +12,6 @@ permissions:
   actions: read
   contents: read
   pull-requests: write
-  security-events: write
 
 jobs:
   dependency-scan:
@@ -72,14 +71,3 @@ jobs:
               issue_number: context.issue.number,
               labels: ['agent:security']
             });
-
-  codeql:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'schedule'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
-        with:
-          languages: javascript-typescript
-      - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

Fixes two GitHub Actions workflows that have been failing on every push since they were introduced:

**1. `check-sf-skills-update.yml` — Expression parse error**
- A bash comment on line 79 contained a literal `${{ }}` (empty expression braces)
- GitHub Actions parses ALL `${{ }}` in `run:` blocks before the shell sees them, including comments
- The empty expression caused the entire workflow to be rejected with "workflow file issue" on every push
- Fix: reworded the comment to avoid the literal `${{ }}` pattern

**2. `security-agent.yml` — CodeQL requires repo setting**
- The CodeQL Analysis job requires "Code Scanning" enabled in repo settings (GitHub Advanced Security)
- Since it's not enabled, the job failed every time with "Code scanning is not enabled for this repository"
- The `dependency-scan` job (secrets scanning, sensitive file detection, JS pattern checks) still provides security coverage
- Fix: removed the CodeQL job and its `security-events: write` permission

## Pre-Landing Review
No issues found. Clean CI-only change.

## Test Coverage
No application code paths changed — CI workflow YAML only. `actionlint` validates both files with zero expression/syntax errors.

## Test plan
- [x] `actionlint` passes on both modified workflows (zero expression/syntax errors)
- [x] pytest: 121 passed, 4 skipped (2 pre-existing failures in unrelated Apex/Flow validators)
- [ ] Verify `check-sf-skills-update.yml` no longer appears as failed check on push events
- [ ] Verify `Security Agent` workflow passes (dependency-scan job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)