### PR TITLE
feat: valencia polish — safety, metrics, branding, docs

### DIFF
--- a/.claude/skills/ohanafy-brand
+++ b/.claude/skills/ohanafy-brand
@@ -1,0 +1,1 @@
+../../skills/ohanafy/ohanafy-brand

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,9 @@ Closes #
 | Metric | Value |
 |--------|-------|
 | Human Estimate (hrs) | |
-| AI Actual (hrs) | |
+| AI Actual (min) | |
+| Tokens Used | |
+| Est. Cost ($) | |
 | Time Saved (%) | |
 
 ## Screenshots / Demo

--- a/.github/workflows/pr-review-agent.yml
+++ b/.github/workflows/pr-review-agent.yml
@@ -85,7 +85,13 @@ jobs:
             WARNINGS="$WARNINGS\n- PR uses \`Relates to\` but no \`Closes #N\` or \`Fixes #N\`. Issues won't auto-close on merge."
           fi
           if ! echo "$PR_BODY" | grep -q 'Time Tracking'; then
-            WARNINGS="$WARNINGS\n- Time tracking section not found or not filled in."
+            WARNINGS="$WARNINGS\n- Time tracking section not found."
+          elif ! echo "$PR_BODY" | grep -E 'Human Estimate.*\|.*[0-9]' <<< "$PR_BODY" 2>/dev/null; then
+            # Check if Time Tracking values are actually populated (not just empty placeholders)
+            HAS_VALUES=$(echo "$PR_BODY" | grep -cE '\|.*[0-9]+.*\|' || true)
+            if [ "$HAS_VALUES" -lt 3 ]; then
+              WARNINGS="$WARNINGS\n- Time tracking section found but values appear empty. Please fill in Human Estimate, AI Actual, Tokens Used, Est. Cost, and Time Saved."
+            fi
           fi
           echo "PR_WARNINGS<<EOF" >> $GITHUB_ENV
           echo -e "$WARNINGS" >> $GITHUB_ENV

--- a/.time-tracking/log.csv
+++ b/.time-tracking/log.csv
@@ -1,0 +1,1 @@
+date,pr_number,branch,description,type,human_estimate_hrs,ai_actual_min,tokens_used,est_cost_usd,time_saved_pct

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Always use the latest available version of each tier.
 4. No direct production DB queries — read replica only
 5. No public S3 buckets
 6. Tray webhooks must validate HMAC signatures
+7. Customer Salesforce orgs are strictly read-only by default — never deploy, push, update, or delete metadata/data in a connected customer org unless the user explicitly authorizes writes in the current conversation
 
 ## Skills (pillar organization)
 
@@ -336,6 +337,24 @@ Ohanafy has extensive existing Tray workflows. Before building anything new in T
 - Tray scripts: use patterns from `integrations/patterns/`, follow validate-transform-batch-output flow
 - Integration scripts: always use `script-scaffold.js` as starting template
 - Commit format: `type(scope): description` — types: feat|fix|agent|skill|docs|ci|eval|chore
+- HTML artifacts: always use Ohanafy 2025 brand template (`docs/templates/demo-template.html`) — Geist font, mellow/cork/dark-denim palette, branded header/footer. Invoke `/ohanafy-brand` skill for brand guidance.
+- Documentation: MD for internal, branded HTML for external (via demo-template.html + /ohanafy-brand), DOCX for client deliverables
+
+## PR Metrics Convention
+
+Every PR must populate the Time Tracking table in the PR description. This is how we measure the value of AI-assisted development.
+
+| Metric | How to estimate |
+|--------|----------------|
+| **Human Estimate (hrs)** | How long would a human developer take to do this work from scratch? Include research, coding, testing, and review time. |
+| **AI Actual (min)** | Wall-clock minutes from session start to PR creation. |
+| **Tokens Used** | Approximate input + output tokens. Estimate ~4K tokens per tool call, ~1K per response turn. |
+| **Est. Cost ($)** | Use Sonnet pricing: $3/1M input, $15/1M output. If Opus was used, $15/1M input, $75/1M output. |
+| **Time Saved (%)** | `((human_hrs × 60 − ai_min) / (human_hrs × 60)) × 100` |
+
+Agents must fill these values when creating PRs. The ship skill is upstream (gstack) — don't modify it. Instead, update the PR body after creation if needed using `gh pr edit`.
+
+Append a row to `.time-tracking/log.csv` after each PR for longitudinal tracking.
 
 ## Never Do
 
@@ -347,6 +366,7 @@ Ohanafy has extensive existing Tray workflows. Before building anything new in T
 - Write CloudFormation directly
 - Query SF production org from skill code
 - Build a new Tray workflow without checking existing ones first
+- Modify, deploy to, or write data/metadata to any connected customer Salesforce org without explicit user authorization — customer orgs are READ-ONLY by default (retrieve only). No `sf project deploy`, no `sf data update`, no `sf apex run`, no destructive changes
 
 ## Hooks
 

--- a/customers/_template/CLAUDE.md
+++ b/customers/_template/CLAUDE.md
@@ -1,5 +1,22 @@
 # Customer: {{CUSTOMER_NAME}}
 
+## READ-ONLY ACCESS — HARD RULE
+
+Customer orgs are **read-only by default**. Do not write to this org unless the user explicitly authorizes it in the current conversation.
+
+**Allowed operations:**
+- `sf org list` — check connected orgs
+- `sf project retrieve start` — pull metadata down
+- `sf data query` — read data via SOQL
+- `sf org display` — view org info
+- `sf org open` — open org in browser
+
+**Prohibited operations (unless user explicitly authorizes):**
+- `sf project deploy start` — deploy metadata
+- `sf data update record` / `sf data create record` / `sf data delete record` — any DML
+- `sf apex run` — anonymous Apex that modifies data
+- Any destructive metadata operations (delete components, overwrite configs)
+
 ## Context loading order
 
 When working on this customer, read files in this order:

--- a/customers/gulf/CLAUDE.md
+++ b/customers/gulf/CLAUDE.md
@@ -1,5 +1,22 @@
 # Customer: Gulf Distributing
 
+## READ-ONLY ACCESS — HARD RULE
+
+Gulf orgs are **read-only by default**. Do not write to any Gulf org unless the user explicitly authorizes it in the current conversation.
+
+**Allowed operations:**
+- `sf org list` — check connected orgs
+- `sf project retrieve start` — pull metadata down
+- `sf data query` — read data via SOQL
+- `sf org display` — view org info
+- `sf org open` — open org in browser
+
+**Prohibited operations (unless user explicitly authorizes):**
+- `sf project deploy start` — deploy metadata
+- `sf data update record` / `sf data create record` / `sf data delete record` — any DML
+- `sf apex run` — anonymous Apex that modifies data
+- Any destructive metadata operations (delete components, overwrite configs)
+
 ## Context loading order
 
 When working on Gulf, read files in this order:

--- a/docs/DOCUMENTATION_STRATEGY.md
+++ b/docs/DOCUMENTATION_STRATEGY.md
@@ -1,0 +1,78 @@
+# Documentation Strategy
+
+How we document the Ohanafy AI Operations Framework — what formats, what to write, and how it becomes the Vercel site.
+
+## Format Matrix
+
+| Format | Audience | When to Use | Template/Tool |
+|--------|----------|-------------|---------------|
+| **Markdown** | Internal / developers | Working docs, skill specs, agent configs, roadmaps | Standard MD, MkDocs-compatible frontmatter |
+| **Branded HTML** | External / demos / Vercel | Integration guides, case studies, showcases, landing pages | `docs/templates/demo-template.html` + `/ohanafy-brand` skill |
+| **DOCX** | Client deliverables | Proposals, SOWs, migration plans, reports | `/docx-builder` skill with python-docx |
+
+**Rule**: Every significant piece of work should produce at least an MD doc. External-facing work should also produce branded HTML.
+
+## Vercel Site Architecture
+
+Static branded HTML — no framework needed. The brand template produces zero-dependency pages at ~30KB each.
+
+```
+docs/site/
+├── index.html              # Landing page: What is the Ohanafy AI Ops Framework?
+├── skills/
+│   └── index.html          # Skill Catalog (auto-generated)
+├── agents/
+│   └── index.html          # Agent Roster (auto-generated)
+├── patterns/
+│   └── index.html          # Integration Pattern Library
+├── guides/
+│   ├── onboarding.html     # Customer Onboarding Guide
+│   ├── integration.html    # Integration Master Guide (branded)
+│   └── faq.html            # FAQ
+├── case-studies/
+│   └── gulf.html           # Gulf: VIP → Ohanafy migration story
+└── vercel.json             # { "outputDirectory": "docs/site" }
+```
+
+**Why no framework?** Docusaurus and MkDocs add build complexity, dependency management, and upgrade churn for what is essentially a collection of standalone HTML pages. The brand template already handles typography, colors, navigation, responsive layout, and print styles. When the site grows beyond ~20 pages, revisit this decision.
+
+## Must-Write Docs (Priority Order)
+
+### Tier 1 — Write first (defines what this is)
+1. **Ohanafy AI Operations Overview** — Landing page. What is this framework, what does it do, who is it for, what results has it delivered.
+2. **Integration Pattern Library** — The 11 production JS modules in `integrations/patterns/`, with examples and when-to-use guidance.
+3. **Skill Catalog** — Auto-generated from `scripts/lint-skills.sh` output. 114 skills organized by pillar with descriptions and trigger conditions.
+
+### Tier 2 — Write next (shows depth)
+4. **Agent Roster** — 19 agents with responsibilities, tools, and handoff rules. Auto-generated from `agents/*/AGENT.md` frontmatter.
+5. **Customer Onboarding Guide** — How to set up a new customer: copy template, connect org, populate profile, configure integrations.
+6. **Gulf Case Study** — Time-to-value story: VIP migration, 8,743 items migrated, what the AI framework enabled.
+
+### Tier 3 — Write as needed (fills gaps)
+7. **FAQ** — Common questions, troubleshooting, how to add skills/agents/customers.
+8. **Configuration Guide** — How to configure the framework: registry, watchers, evals, content sources.
+9. **AI Velocity Report** — Aggregate PR metrics from `.time-tracking/log.csv` into a dashboard page.
+
+## Auto-Generation Opportunities
+
+| What | Source | How |
+|------|--------|-----|
+| Skill Catalog | `scripts/lint-skills.sh` | Add `--html` flag to output branded HTML table |
+| Agent Roster | `agents/*/AGENT.md` | Parse YAML frontmatter, generate HTML roster |
+| Integration Patterns | `integrations/patterns/*.js` | Extract JSDoc headers, generate reference page |
+| PR Metrics Dashboard | `.time-tracking/log.csv` | Aggregate CSV into summary HTML with charts |
+
+## What NOT to Do
+
+- Do not set up Docusaurus or MkDocs (overhead not justified yet)
+- Do not repurpose `integrations/marketplace-ui/` as a doc site (it's a Tray config app)
+- Do not duplicate content that lives in skills — link to the skill instead
+- Do not create docs without using the brand template for external-facing output
+
+## Documentation Workflow
+
+1. **During development**: Write MD docs in `docs/` as you work
+2. **At PR time**: Generate branded HTML for any external-facing docs using the demo template
+3. **After ship**: `/document-release` skill auto-updates README, ARCHITECTURE, CHANGELOG
+4. **Periodic**: Auto-generate skill catalog and agent roster HTML
+5. **When ready**: Deploy `docs/site/` to Vercel

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,10 +39,37 @@
 - [ ] Auto-freshness: skill checks source index staleness and auto-triggers sync when >7 days
 - [ ] Cross-customer pattern detection: diff customer profiles to find reusable patterns
 - [ ] Build connector-specific skills: `tray-netsuite`, `tray-qbo`, `tray-ukg-pro`
-- [ ] Create Ohanafy brand/voice skill for customer-facing docs
+- [x] Create Ohanafy brand/voice skill for customer-facing docs (installed from integrations repo)
 - [ ] Add pre-commit hooks for skill schema validation
 - [ ] Build integration test suite for skills (trigger-rule coverage)
 - [ ] Enhance `connect-org.sh` to capture richer metadata (installed package versions, active flows, validation rules, custom fields per object)
+
+## Future: Internal Salesforce Org Integration
+
+Ohanafy logs all activity in an internal Salesforce org. PR and AI activity should eventually flow there too.
+
+- [ ] Define `PR_Activity__c` custom object schema (PR number, branch, human estimate, AI time, tokens, cost, summary, labels)
+- [ ] Build Tray webhook workflow: GitHub PR webhook → Tray → SF Composite API upsert to internal org
+- [ ] Create `sf-internal-logger` skill for manual activity logging to the internal org
+- [ ] Wire into ship workflow as post-step (after PR creation, log to SF)
+- [ ] Build SF dashboard for AI velocity metrics (time saved per PR, cost trends, tokens over time, team productivity)
+
+**Implementation path**: GitHub webhook fires on PR events → Tray receives payload → transforms using `batch-processing.js` + `data-mapping.js` patterns → upserts `PR_Activity__c` via SF Composite API. Token costs come from `skills/claude/model-router/skill.py` pricing. Time metrics come from `.time-tracking/log.csv`.
+
+## Future: Vercel Documentation Site
+
+Static branded HTML site showcasing what the AI ops framework does.
+
+- [ ] Create `docs/site/` directory with `index.html` landing page (use `docs/templates/demo-template.html`)
+- [ ] Generate Skill Catalog HTML (auto-generate from `scripts/lint-skills.sh` output)
+- [ ] Generate Agent Roster HTML (from `agents/*/AGENT.md` frontmatter)
+- [ ] Write Integration Pattern Library page (from `integrations/patterns/`)
+- [ ] Write Customer Onboarding Guide
+- [ ] Write Gulf case study (time-to-value story)
+- [ ] Add `vercel.json` pointing `outputDirectory` to `docs/site/`
+- [ ] Deploy with `vercel --prod`
+
+**Key decision**: No framework (no Docusaurus, no MkDocs). The brand template produces zero-dependency HTML at ~30KB. Keep it simple.
 
 ## Longer-Term (3-6 Months)
 - [ ] Multi-agent orchestration: FDE strategist delegates to SKU experts automatically
@@ -75,3 +102,7 @@
 | 2026-04-04 | Machine user PAT for sync | Single PAT with read-only org scope is simpler than per-repo deploy keys |
 | 2026-04-04 | Static grep for service graphs | One level deep, static patterns only. Coverage limitations documented in index. |
 | 2026-04-04 | Commit org snapshots as markdown | Committed for agent access; raw JSON gitignored. Regenerate on-demand via connect-org.sh |
+| 2026-04-07 | Customer orgs read-only by default | Safety rule: never modify customer orgs unless user explicitly authorizes in conversation |
+| 2026-04-07 | PR metrics on every PR | Track human estimate, AI time, tokens, cost, and time saved percentage |
+| 2026-04-07 | Static HTML for Vercel site | No framework — brand template produces zero-dependency HTML. Simpler than Docusaurus/MkDocs |
+| 2026-04-07 | SF internal org logging via Tray | Future: PR activity flows to internal SF org via GitHub webhook → Tray → Composite API |

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,55 @@
+# Ohanafy HTML Templates
+
+## Brand Template (`demo-template.html`)
+
+The standard Ohanafy 2025 brand template for all external-facing HTML artifacts. Zero dependencies, ~30KB overhead.
+
+### Usage
+
+Copy the template and replace the two placeholders:
+- `$title$` — Page title (appears in `<title>` and `.doc-title`)
+- `$body$` — Page content (HTML inside `.content` div)
+
+### CSS Variables (Color Palette)
+
+| Variable | Hex | Usage |
+|----------|-----|-------|
+| `--true-black` | `#000000` | Text, high-contrast elements |
+| `--true-white` | `#FFFFFF` | Backgrounds, reversed text |
+| `--mellow` | `#E4F223` | Primary accent, CTA highlights (use sparingly) |
+| `--cork` | `#F4F2F0` | Neutral backgrounds, cards |
+| `--dark-denim` | `#4A5F80` | Secondary UI, headers, borders |
+| `--light-denim` | `#B1C7EB` | Subtle accents, hover states |
+| `--dark-grey` | `#545454` | Body text, secondary text |
+
+### Typography
+
+Font: **Geist** (loaded from Google Fonts). Falls back to system sans-serif.
+
+### Structure
+
+```html
+<div class="brand-header">   <!-- Black banner with mellow/white tagline -->
+<div class="doc-nav">         <!-- Dark denim nav bar (customize links) -->
+<div class="content">          <!-- White content area, max-width 900px -->
+<div class="brand-footer">    <!-- Centered footer with tagline -->
+```
+
+### Built-in Classes
+
+- `.time-tracking` — Styled callout box for metrics
+- `.highlight-inline` / `<mark>` — Mellow highlight
+- `blockquote` — Mellow left-border callout
+- `pre` — Cork background code block with denim border
+- Tables — Denim headers, cork rows, denim hover
+
+### When to Use
+
+- Integration documentation HTML
+- Case study pages
+- Demo artifacts
+- Any external-facing page that will eventually be hosted on Vercel
+
+### Brand Skill
+
+For full brand guidelines (voice, messaging, logo rules), invoke `/ohanafy-brand` or read `skills/ohanafy/ohanafy-brand/SKILL.md`.

--- a/skills/ohanafy/ohanafy-brand/SKILL.md
+++ b/skills/ohanafy/ohanafy-brand/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: ohanafy-brand
+description: "Apply Ohanafy's official 2025 brand guidelines to any artifact — presentations, web pages, documents, UI components, marketing copy, or visual designs. Use when creating or styling Ohanafy-branded content including dashboards, slides, emails, landing pages, social media assets, reports, or any output that should match Ohanafy's visual identity and brand voice. Triggers on: Ohanafy branding, brand it, apply our brand, make it on-brand, Ohanafy style, brand guidelines."
+---
+
+# Ohanafy Brand Guidelines (2025)
+
+Read `references/brand.md` for full messaging library, copy examples, and detailed guidance.
+
+## Color Palette
+
+### Primary Colors
+| Name       | Hex       | Usage |
+|------------|-----------|-------|
+| True Black | `#000000` | Text, high-contrast elements |
+| True White | `#FFFFFF` | Backgrounds, reversed text |
+| Mellow     | `#E4F223` | Primary accent, CTA highlights |
+| Cork       | `#F4F2F0` | Neutral backgrounds, cards |
+
+### Accent Colors
+| Name        | Hex       | Usage |
+|-------------|-----------|-------|
+| Dark Denim  | `#4A5F80` | Secondary UI, headers |
+| Light Denim | `#B1C7EB` | Subtle accents, hover states |
+| Dark Grey   | `#545454` | Body text, secondary text |
+
+**Key principle**: Mellow (`#E4F223`) is a highlighter — use it sparingly for emphasis and CTAs, never as a base color.
+
+## Typography
+
+Font family: **Geist** (all weights). Fall back to system sans-serif only if unavailable.
+
+| Style    | Size  | Weight     |
+|----------|-------|------------|
+| Title    | 54pt  | ExtraBold  |
+| ST1      | 36pt  | ExtraLight |
+| H1       | 24pt  | Regular    |
+| H2       | 18pt  | Bold       |
+| Body (P) | 16pt  | Regular    |
+
+## Logo Usage
+
+- **Preferred**: All-black or all-white logos
+- Available formats: Horizontal, Vertical, Emblem
+- Never distort, recolor, or add effects
+
+## Brand Voice
+
+Authentic, confident, approachable. Grounded in expertise without arrogance. Clear and outcomes-focused — no fluff. Write like a trusted partner who understands the beverage industry challenges.
+
+## Core Identity Snapshot
+
+- **Mission**: Transforming the beverage industry through automation, dedication, and speed.
+- **Vision**: The Leader in Beverage Innovation
+- **Primary tagline**: "The AI-Powered Operating System for Beverage"
+- **Elevator pitch**: "Ohanafy makes your day-to-day tasks easier while empowering you to make better data-driven decisions faster. We've partnered with Salesforce to provide beverage-specific solutions focused on saving time and making money."
+
+## Application Workflow
+
+1. Identify output type (web, slide, doc, email, social, etc.)
+2. Set background: Cork (`#F4F2F0`) for light surfaces, True Black for dark/reversed
+3. Apply Mellow (`#E4F223`) as accent on CTAs, highlights, key stats — not backgrounds
+4. Use Dark Denim (`#4A5F80`) for secondary UI elements and section headers
+5. Set all type in **Geist**
+6. Align copy with brand voice: direct, confident, human, beverage-industry-savvy
+7. For messaging, see `references/brand.md` for approved taglines, boilerplate, and value props

--- a/skills/ohanafy/ohanafy-brand/references/brand.md
+++ b/skills/ohanafy/ohanafy-brand/references/brand.md
@@ -1,0 +1,108 @@
+# Ohanafy Brand Reference — 2025
+
+## Table of Contents
+1. [Mission & Vision](#mission--vision)
+2. [Core Values](#core-values)
+3. [Positioning](#positioning)
+4. [Brand Voice](#brand-voice)
+5. [Approved Messaging](#approved-messaging)
+6. [Value Propositions](#value-propositions)
+7. [Company Story](#company-story)
+8. [Name Origin](#name-origin)
+
+---
+
+## Mission & Vision
+
+- **Mission**: Transforming the beverage industry through automation, dedication, and speed.
+- **Vision**: The Leader in Beverage Innovation
+
+---
+
+## Core Values
+
+1. Trust
+2. Customer Success
+3. Do the Right Thing
+4. Innovation
+5. Exceed Expectations
+
+---
+
+## Positioning
+
+Key differentiators:
+- **Speed** — fast execution and implementation
+- **Customer Support** — high-touch, responsive
+- **Technology** — modern, AI-powered, Salesforce-native
+- **Ownership** — accountability and results
+
+---
+
+## Brand Voice
+
+Ohanafy's brand voice is authentic and human-like, putting people before products and speaking in a way that feels natural and relatable. It's **confident**, sometimes bold, but approachable — grounded in expertise and technology without sounding arrogant or overly technical.
+
+Strip away the fluff. Keep things straightforward. Focus on clarity, outcomes, and real stories that highlight how we help customers succeed.
+
+Every piece of content should feel genuine, clear, and energizing — like a conversation with a trusted partner who understands the challenges of the beverage industry and is committed to helping people win.
+
+**Do**: Direct, specific, outcomes-focused, beverage-industry-savvy, warm
+**Don't**: Jargon-heavy, generic tech speak, corporate fluff, arrogant
+
+---
+
+## Approved Messaging
+
+### Taglines & Statements
+- "The AI-Powered Operating System for Beverage" *(primary)*
+- "Revolutionizing Beverage Operations with AI-Powered Precision"
+- "Modern beverage runs on Ohanafy"
+- "The Future of Beverage Technology"
+- "Modern Technology for the Modern Beverage Brand/Distributor"
+- "Modernize today. Lead with confidence tomorrow."
+
+### Boilerplate (full)
+Ohanafy is the AI-powered operating system for the beverage industry. Powered by Salesforce and built specifically for suppliers and wholesalers, Ohanafy combines modern usability with advanced intelligence to simplify operations, streamline decisions, and unlock growth. Founded to bring innovation and speed to an underserved industry, Ohanafy delivers technology that helps beverage companies work smarter today and lead with confidence tomorrow.
+
+### Elevator Pitch
+**What is Ohanafy?**
+Ohanafy makes your day-to-day tasks easier while empowering you to make better data-driven decisions faster.
+
+**How do we do that?**
+We've partnered with Salesforce to provide beverage-specific solutions focused on saving time and making money.
+
+---
+
+## Value Propositions
+
+- Cut operating costs
+- Increase efficiency
+- Reduce inventory waste
+- Deliver faster, sell more
+- Sell the right products
+- Protect your bottom line
+
+---
+
+## Company Story
+
+Founded in Wilmington, NC in May 2022 and launched that September, Ohanafy was created to bring modern technology to an industry that had long been underserved. With deep expertise in Salesforce, our founders recognized that while innovation was transforming many sectors, beverage businesses lacked the tools needed to keep pace.
+
+Today, Ohanafy partners with beverage companies of all sizes and categories, delivering flexible, scalable solutions that drive efficiency, insights, and growth. We put people before products, focusing on the real challenges distributors and suppliers face, and providing the technology to help them thrive — not just today, but well into the future.
+
+---
+
+## Name Origin
+
+"Ohana" is a Hawaiian word that means family — but not just the people you're related to. It includes the people you rely on, the people who rely on you, and the systems that keep everything moving together.
+
+Wholesalers sit at the center of a complex network: suppliers, sales reps, drivers, retailers, finance teams, etc. When systems are disconnected, that "Ohana" breaks down. Information gets lost, teams work in silos, and execution suffers.
+
+Ohanafy is about turning a fragmented operation into a connected one.
+
+---
+
+## Platform Modules (for context in content)
+
+RAS · CRM · Retail Execution · OMS · WMS · Analytics · E-Commerce · Maps · Hubs · Data · Payments

--- a/skills/utility/org-connect/SKILL.md
+++ b/skills/utility/org-connect/SKILL.md
@@ -41,6 +41,23 @@ sf org list
 sf project retrieve start --target-org <alias> --manifest ./package.xml
 ```
 
+## CRITICAL: Read-Only Operations Only
+
+Customer orgs are **read-only by default**. Do not write to any customer org unless the user explicitly authorizes it in the current conversation.
+
+**Allowed operations:**
+- `sf org list` — check connected orgs
+- `sf project retrieve start` — pull metadata down
+- `sf data query` — read data via SOQL
+- `sf org display` — view org info
+- `sf org open` — open org in browser
+
+**Prohibited operations (unless user explicitly authorizes):**
+- `sf project deploy start` — deploy metadata
+- `sf data update record` / `sf data create record` / `sf data delete record` — any DML
+- `sf apex run` — anonymous Apex that modifies data
+- Any destructive metadata operations (delete components, overwrite configs)
+
 ## What the Script Does
 
 1. **Creates project directory** under `customers/<name>/orgs/<env>/`


### PR DESCRIPTION
## Summary
- **Customer org read-only rule**: Hard safety guardrail across CLAUDE.md, customer templates, and org-connect skill — no writes to customer orgs unless explicitly authorized
- **PR metrics**: Expanded Time Tracking table (tokens, cost), stronger CI validation, CLAUDE.md convention for agents to populate metrics on every PR
- **Ohanafy branding**: Installed `ohanafy-brand` skill, added HTML/doc conventions, documented the brand template
- **SF internal org logging**: Vision captured in roadmap (PR_Activity__c → Tray webhook → SF dashboard) for future build
- **Documentation strategy**: Format matrix, Vercel static site plan, prioritized must-write docs, auto-generation opportunities

## Time Tracking
| Metric | Value |
|--------|-------|
| Human Estimate (hrs) | 6 |
| AI Actual (min) | 25 |
| Tokens Used | ~180K |
| Est. Cost ($) | ~3.25 |
| Time Saved (%) | 93% |

## Test plan
- [ ] Verify `CLAUDE.md` Security Rule #7 and Never Do entry for customer org read-only
- [ ] Verify `customers/_template/CLAUDE.md` and `customers/gulf/CLAUDE.md` have READ-ONLY section
- [ ] Verify `skills/utility/org-connect/SKILL.md` has Read-Only Operations section
- [ ] Verify PR template has Tokens Used and Est. Cost rows
- [ ] Verify `pr-review-agent.yml` checks for populated values (not just section existence)
- [ ] Verify `.claude/skills/ohanafy-brand` symlink resolves to SKILL.md
- [ ] Verify `.time-tracking/log.csv` exists with correct headers
- [ ] Verify `docs/DOCUMENTATION_STRATEGY.md` covers format matrix, Vercel plan, must-write docs
- [ ] Verify `docs/roadmap.md` has SF logging and Vercel site future sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)