### PR TITLE
chore(registry): add dzeder/Integrations as Tray reference repo

### DIFF
--- a/registry/ohanafy-repos.yaml
+++ b/registry/ohanafy-repos.yaml
@@ -1,6 +1,6 @@
 version: "1.0"
 status: "ACTIVE"
-total_repos: 55
+total_repos: 56
 last_discovered: "2026-04-07"
 rules:
   - "Check this registry before any PR in an Ohanafy product repo"
@@ -338,6 +338,19 @@ repos:
     stack: []
     active: true
     notes: "Integration configs and middleware"
+
+  - name: dzeder/Integrations
+    type: reference
+    sku: all
+    stack: [JavaScript, Tray.io]
+    active: true
+    url: "https://github.com/dzeder/Integrations.git"
+    notes: >
+      Daniel's integration working repo — 88+ Tray Embedded projects with raw exports,
+      extracted scripts, configs, diagrams. Source of truth for real Tray workflow JSON
+      structure. Key paths: 01-tray/Embedded/{ProjectName}/raw-exports/ for real exports,
+      scripts/ for extracted script steps with input.json and test-runner.js.
+      2.5GB — clone on demand, never pull into irvine.
 
   - name: OHFY-Offline
     type: backend


### PR DESCRIPTION
## Summary
- Register `dzeder/Integrations` (88+ real Tray Embedded projects) in `registry/ohanafy-repos.yaml` as a clone-on-demand reference source
- Learned real Tray JSON export format from Daniel's TBM Draft Invoice Item workflow — saved to AI memory for future Tray workflow generation

## Context
Attempted to generate a Tray workflow JSON from scratch and discovered the docs guide was inaccurate vs real exports. Analyzed Daniel's working workflow to learn the actual format (typed values, `raw_http_request` for SF queries, `alerting-trigger` for error handling, etc.). Rather than storing raw exports in irvine (which would bloat it), we reference the Integrations repo and clone on demand.

## Time Tracking

| Metric | Value |
|--------|-------|
| Human Estimate (hrs) | 1 |
| AI Actual (min) | 45 |
| Tokens Used | ~80K |
| Est. Cost ($) | ~$8 |
| Time Saved (%) | 25% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)