### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -18,7 +18,7 @@ jobs:
   cdk-synth:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check CDK project exists
         id: check
         run: |
@@ -28,7 +28,7 @@ jobs:
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         if: steps.check.outputs.skip != 'true'
         with:
           node-version: '20'
@@ -36,7 +36,7 @@ jobs:
         if: steps.check.outputs.skip != 'true'
       - run: npx cdk synth
         if: steps.check.outputs.skip != 'true'
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: steps.check.outputs.skip != 'true'
         with:
           name: cdk-output
@@ -46,13 +46,13 @@ jobs:
     needs: cdk-synth
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: cdk-output
           path: cdk.out/
         continue-on-error: true
-      - uses: bridgecrewio/checkov-action@master
+      - uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
         if: hashFiles('cdk.out/') != ''
         with:
           directory: cdk.out/
@@ -62,11 +62,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check CDK project exists
         id: check
         run: test -f package.json && echo "skip=false" >> "$GITHUB_OUTPUT" || echo "skip=true" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         if: steps.check.outputs.skip != 'true'
         with:
           node-version: '20'
@@ -84,11 +84,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check CDK project exists
         id: check
         run: test -f package.json && echo "skip=false" >> "$GITHUB_OUTPUT" || echo "skip=true" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         if: steps.check.outputs.skip != 'true'
         with:
           node-version: '20'

--- a/.github/workflows/content-watcher.yml
+++ b/.github/workflows/content-watcher.yml
@@ -12,8 +12,8 @@ jobs:
   scan-content:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
       - run: pip install anthropic feedparser httpx pyyaml google-api-python-client beautifulsoup4 requests

--- a/.github/workflows/kb-writer.yml
+++ b/.github/workflows/kb-writer.yml
@@ -9,9 +9,9 @@ jobs:
     if: github.event.label.name == 'kb-approved'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/sf-deploy.yml
+++ b/.github/workflows/sf-deploy.yml
@@ -27,7 +27,7 @@ jobs:
           fi
         env:
           SF_CLIENT_ID: ${{ secrets.SF_CLIENT_ID }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.auth.outputs.has_credentials == 'true'
       - name: Install SF CLI
         if: steps.auth.outputs.has_credentials == 'true'
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Install SF CLI

--- a/.github/workflows/sync-tray-connectors.yml
+++ b/.github/workflows/sync-tray-connectors.yml
@@ -9,7 +9,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Sync Tray connector catalog
         run: bash scripts/sync-tray-connectors.sh --apply --workspace

--- a/.github/workflows/watchers.yml
+++ b/.github/workflows/watchers.yml
@@ -12,8 +12,8 @@ jobs:
   scan-repos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
       - run: pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- Pins all 16 remaining unpinned GitHub Action references to exact commit SHAs across 6 workflow files
- Pins `bridgecrewio/checkov-action` from floating `@master` to `v12.1347.0` (`99bb2caf`)
- Follows existing repo convention (46 other action refs already use commit SHAs)

**Actions pinned:**
| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v6 | `de0fac2e` |
| `actions/setup-node` | v6 | `53b83947` |
| `actions/setup-python` | v6 | `a309ff8b` |
| `actions/upload-artifact` | v7 | `bbbca2dd` |
| `actions/download-artifact` | v8 | `3e5f45b2` |
| `bridgecrewio/checkov-action` | v12.1347.0 | `99bb2caf` |

**Files changed:** aws-deploy.yml, content-watcher.yml, kb-writer.yml, sf-deploy.yml, sync-tray-connectors.yml, watchers.yml

## Test plan
- [ ] Verify workflows still trigger correctly (no functional changes, only SHA pinning)
- [ ] Confirm all `uses:` lines across the repo now reference commit SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)