### PR TITLE
fix(vip-srs): quick wins, cleanup safety gate, and allocation date fix

### DIFF
--- a/integrations/vip-srs/ROADMAP.md
+++ b/integrations/vip-srs/ROADMAP.md
@@ -91,6 +91,14 @@
 - [x] Updated e2e-sandbox-runner.js: placements wired into pipeline (Phase 4), fixtures switched to slsda-25.csv
 - [x] All phase 4 objects (Depletions, Placements, Allocations) verified with correct file date
 
+### Phase 5d: Quick Wins + Cleanup Hardening (2026-04-10)
+- [x] Script 07 (depletions): Set `ohfy__Type__c = 'Sale'` — depletions now visible in Type-filtered reports
+- [x] Script 08 (allocations): Set `ohfy__End_Date__c` (last day of month) + `ohfy__Location__r` (distributor warehouse lookup)
+- [x] Script 05 (accounts): Set `ohfy__Fulfillment_Location__r` on retailer accounts (links to `LOC:{DistId}`)
+- [x] Script 06 (inventory): Set `ohfy__Status__c = 'Complete'` on Inventory_Adjustment__c records
+- [x] Script 09 (cleanup): Added `countQuery` (SELECT COUNT()) per target for sanity check — Tray workflow should compare stale count vs upsert count before deleting; if stale > upserted, skip delete (possible truncated/partial file)
+- [x] **Key decision documented:** Invoice__c/Invoice_Item__c is NOT built from VIP data. VIP SLSDA = distributor→retailer depletions (Depletion__c + Placement__c). Invoice objects are for supplier→distributor invoicing — a separate data source entirely.
+
 ## Next Up
 
 ### Phase 6: Tray.io Project Build
@@ -130,6 +138,7 @@
 | **Permission Set** for FLS | Easier to assign to any integration user than modifying every profile |
 | **Deploy package includes Admin.profile FLS** | SF Metadata API silently fails without it in subscriber orgs |
 | **Placement__c keyed by Account×Item** (not per invoice line) | One placement per distributor+account+item. Aggregated from SLSDA rows: earliest/latest sold dates, latest price/qty. External ID: `PLC:{DistId}:{AcctNbr}:{SuppItem}` |
+| **No Invoice__c from VIP data** | VIP SLSDA = distributor→retailer depletions (Depletion__c + Placement__c). Invoice__c is for supplier→distributor invoicing — different data source, not from VIP files |
 | **VIP_File_Date__c = date of pipeline run** | Not derived from file contents. FromDate/ToDate capture the file's reporting window. File date stamps when a record was last refreshed, enabling stale cleanup. |
 
 ## Gotchas

--- a/integrations/vip-srs/scripts/05-outda-accounts.js
+++ b/integrations/vip-srs/scripts/05-outda-accounts.js
@@ -218,6 +218,9 @@ function transformAccount(row, distId) {
     // Store number
     var store = clean(row.Store);
     if (store) record.ohfy__Store_Number__c = store;
+
+    // Link to distributor's warehouse location
+    record.ohfy__Fulfillment_Location__r = { VIP_External_ID__c: 'LOC:' + distId };
   }
 
   return record;

--- a/integrations/vip-srs/scripts/06-invda-inventory.js
+++ b/integrations/vip-srs/scripts/06-invda-inventory.js
@@ -135,6 +135,7 @@ function transformAdjustment(row, distId, transCodeInfo, fileDate) {
   record.VIP_External_ID__c = adjustmentKey(distId, supplierItem, transCode, transDate, uom);
   record[NS + 'Type__c'] = transCodeInfo.type;
   record[NS + 'Reason__c'] = transCodeInfo.reason;
+  record[NS + 'Status__c'] = 'Complete';
   record[NS + 'Date__c'] = toSfDate(transDate);
   record[NS + 'Quantity_Change__c'] = toInt(row.Quantity);
   // Parent Inventory lookup (relationship syntax)

--- a/integrations/vip-srs/scripts/07-slsda-depletions.js
+++ b/integrations/vip-srs/scripts/07-slsda-depletions.js
@@ -81,6 +81,9 @@ function transformDepletion(row, distId, fileDate) {
   record[NS + 'Item__r'] = {};
   record[NS + 'Item__r'][NS + 'VIP_External_ID__c'] = itemKey(suppItem);
 
+  // Depletion type — all VIP SLSDA records are sales
+  record[NS + 'Type__c'] = 'Sale';
+
   // Case vs Bottle quantity
   if (uom === 'C') {
     record[NS + 'Case_Quantity__c'] = qty;

--- a/integrations/vip-srs/scripts/08-ctlda-allocations.js
+++ b/integrations/vip-srs/scripts/08-ctlda-allocations.js
@@ -16,7 +16,7 @@
 // INLINE SHARED
 // =============================================================================
 
-var PREFIX = { ITEM: 'ITM', ALLOCATION: 'ALC' };
+var PREFIX = { ITEM: 'ITM', ALLOCATION: 'ALC', LOCATION: 'LOC' };
 var SF_CONFIG = { apiVersion: 'v62.0', batchSize: 25, namespacePrefix: 'ohfy' };
 var NS = SF_CONFIG.namespacePrefix + '__';
 
@@ -29,6 +29,18 @@ function toSfMonthDate(yyyymm) {
   if (!yyyymm || String(yyyymm).length < 6) return '';
   var s = String(yyyymm);
   return s.substring(0, 4) + '-' + s.substring(4, 6) + '-01';
+}
+
+function toSfEndOfMonth(yyyymm) {
+  if (!yyyymm || String(yyyymm).length < 6) return '';
+  var s = String(yyyymm);
+  var year = parseInt(s.substring(0, 4), 10);
+  var month = parseInt(s.substring(4, 6), 10);
+  // Day 0 of next month = last day of current month
+  var lastDay = new Date(year, month, 0).getDate();
+  var mm = month < 10 ? '0' + month : '' + month;
+  var dd = lastDay < 10 ? '0' + lastDay : '' + lastDay;
+  return year + '-' + mm + '-' + dd;
 }
 
 function toInt(v) {
@@ -74,12 +86,19 @@ function transformAllocation(row, distId, fileDate) {
   record[NS + 'Item__r'] = {};
   record[NS + 'Item__r'][NS + 'VIP_External_ID__c'] = itemKey(supplierItem);
 
+  // Location lookup (distributor's warehouse)
+  record[NS + 'Location__r'] = { VIP_External_ID__c: PREFIX.LOCATION + ':' + distId };
+
   // Allocated_Case_Amount__c is the correct writable quantity field
   record[NS + 'Allocated_Case_Amount__c'] = toInt(row.Quantity);
   record[NS + 'Start_Date__c'] = toSfMonthDate(controlDate);
+  record[NS + 'End_Date__c'] = toSfEndOfMonth(controlDate);
   record[NS + 'Is_Active__c'] = true;
 
-  // Stale cleanup (unmanaged custom fields)
+  // Stale cleanup dates (unmanaged custom fields)
+  // Derive From/To from ControlDate month boundaries so cleanup script 09 can match
+  record.VIP_From_Date__c = toSfMonthDate(controlDate);
+  record.VIP_To_Date__c = toSfEndOfMonth(controlDate);
   if (fileDate) record.VIP_File_Date__c = fileDate;
 
   return record;

--- a/integrations/vip-srs/scripts/09-cleanup-stale.js
+++ b/integrations/vip-srs/scripts/09-cleanup-stale.js
@@ -70,6 +70,14 @@ function buildStaleQuery(target, distId, currentFileDate, fromDate, toDate) {
     " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
 }
 
+function buildCountQuery(target, distId, currentFileDate, fromDate, toDate) {
+  return 'SELECT COUNT() FROM ' + target.sobject +
+    ' WHERE ' + target.fileDateField + ' < ' + currentFileDate +
+    ' AND ' + target.fromDateField + ' >= ' + fromDate +
+    ' AND ' + target.toDateField + ' <= ' + toDate +
+    " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+}
+
 // =============================================================================
 // ORCHESTRATOR
 // =============================================================================
@@ -102,12 +110,17 @@ exports.step = function(input) {
   }
 
   // Generate stale cleanup queries for each target object
+  // Each target includes a countQuery for safety validation:
+  // compare stale count vs upsert count from the same run.
+  // If stale count > upsert count, the file may be truncated — skip cleanup and alert.
   var queries = CLEANUP_TARGETS.map(function(target) {
     return {
       sobject: target.sobject,
       prefix: target.prefix,
       purpose: 'Delete stale ' + target.sobject + ' records',
-      soql: buildStaleQuery(target, distId, currentFileDate, fromDate, toDate)
+      soql: buildStaleQuery(target, distId, currentFileDate, fromDate, toDate),
+      countQuery: buildCountQuery(target, distId, currentFileDate, fromDate, toDate),
+      safetyNote: 'Compare stale count against upsert count for ' + target.sobject + '. If stale > upserted, skip delete (possible truncated file).'
     };
   });
 


### PR DESCRIPTION
## Summary

Addresses 5 quick wins + 1 bug found during adversarial review for the VIP SRS supplier integration (Shipyard/ROS). These are data quality fixes to existing transform scripts.

**Quick Wins (from specialist review):**
- **Script 07** (depletions): Set `ohfy__Type__c = 'Sale'` — depletions now visible in Type-filtered reports
- **Script 08** (allocations): Set `ohfy__End_Date__c` (last day of month) + `ohfy__Location__r` (distributor warehouse lookup)
- **Script 05** (accounts): Set `ohfy__Fulfillment_Location__r` on retailer accounts → links to `LOC:{DistId}`
- **Script 06** (inventory): Set `ohfy__Status__c = 'Complete'` on Inventory_Adjustment__c records

**Cleanup Hardening:**
- **Script 09**: Added `countQuery` (SELECT COUNT()) per cleanup target. Tray workflow should compare stale count vs upsert count before deleting — blocks cleanup if truncated file would wipe good data
- **Script 08**: Fixed silent bug where `VIP_From_Date__c` and `VIP_To_Date__c` were never set on Allocation__c, causing cleanup script 09 to always match zero records (stale allocations accumulated indefinitely)

**Key Decision Documented:**
Invoice__c/Invoice_Item__c is NOT built from VIP data. VIP SLSDA = distributor→retailer depletions (Depletion__c + Placement__c). Invoice objects are for supplier→distributor invoicing — a different data source entirely.

## Pre-Landing Review

No issues found. All changes are simple field additions to existing transform functions following established patterns.

## Adversarial Review

8 findings from Claude adversarial subagent. 1 HIGH fixed (Allocation From/To dates), 3 MEDIUM informational (restricted picklist values need org verification, Placement__c cleanup needs different strategy), 4 LOW pre-existing.

## Plan Completion

8/8 plan items DONE.

## Test plan
- [x] Script 05 (accounts): 6/6 tests pass
- [x] Script 06 (inventory): 6/6 tests pass
- [x] Script 07 (depletions): 6/6 tests pass
- [x] Script 08 (allocations): 6/6 tests pass
- [x] Allocation From/To dates verified: `2026-04-01` / `2026-04-30` for ControlDate `202604`
- [x] Depletion Type__c = 'Sale' verified in transform output
- [x] Adjustment Status__c = 'Complete' verified in transform output
- [x] Fulfillment_Location__r verified on retailer accounts (not distributors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)