### PR TITLE
fix(ci): disable repo watchers cron until implementation exists

### DIFF
--- a/.github/workflows/watchers.yml
+++ b/.github/workflows/watchers.yml
@@ -1,11 +1,9 @@
-# Trigger: cron "0 8 * * MON"
 # Jobs: scan all repos in repos.yaml, post digest to Slack
+# TODO: Re-enable cron schedule once agents/watchers/agent.py and requirements.txt exist (see #89)
 
 name: Repo Watchers
 
 on:
-  schedule:
-    - cron: '0 8 * * MON'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Removes the weekly cron schedule from the Repo Watchers workflow to stop recurring Monday failures
- The workflow referenced `requirements.txt` and `python -m agents.watchers.agent` which were never created
- Keeps `workflow_dispatch` so it can be triggered manually once the implementation is built

Closes #89

## Test plan
- [ ] Verify no more scheduled runs trigger on Monday
- [ ] Manual dispatch still available in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)