### PR TITLE
Fix gstack update workflow symlink failure

### DIFF
--- a/.github/workflows/check-gstack-update.yml
+++ b/.github/workflows/check-gstack-update.yml
@@ -66,7 +66,10 @@ jobs:
           if [ -n "$EXISTING_PR" ]; then
             echo "PR #${EXISTING_PR} already exists for ${BRANCH}, updating..."
             git checkout -b "$BRANCH"
-            git add .claude/skills/gstack/ .claude/skills/*/SKILL.md
+            git add .claude/skills/gstack/
+            for f in .claude/skills/*/SKILL.md; do
+              [ ! -L "$(dirname "$f")" ] && git add "$f"
+            done
             git commit -m "chore: update gstack from ${LOCAL_VER} to ${UPSTREAM_VER}"
             git push origin "$BRANCH" --force
             echo "Updated existing PR #${EXISTING_PR}"
@@ -77,7 +80,10 @@ jobs:
           git push origin --delete "$BRANCH" 2>/dev/null || true
 
           git checkout -b "$BRANCH"
-          git add .claude/skills/gstack/ .claude/skills/*/SKILL.md
+          git add .claude/skills/gstack/
+          for f in .claude/skills/*/SKILL.md; do
+            [ ! -L "$(dirname "$f")" ] && git add "$f"
+          done
           git commit -m "chore: update gstack from ${LOCAL_VER} to ${UPSTREAM_VER}"
           git push origin "$BRANCH"
           {


### PR DESCRIPTION
## Summary
- The weekly "Check gstack upstream updates" workflow failed because `git add .claude/skills/*/SKILL.md` expanded through the `ohanafy-brand` directory symlink, causing git to error with "pathspec beyond a symbolic link"
- Replaced the glob with a loop that skips directory symlinks, applied to both code paths (existing PR update + new PR creation)

Fixes #90

## Test plan
- [ ] Merge this PR — the workflow's `push.paths` trigger will auto-run it
- [ ] Verify the re-triggered run creates the gstack 0.16.3.0 update PR successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)