### PR TITLE
feat(vip-srs): add Placement__c to stale cleanup, complete Phase 5

### DIFF
--- a/integrations/vip-srs/ROADMAP.md
+++ b/integrations/vip-srs/ROADMAP.md
@@ -55,7 +55,11 @@
   - `02-itm2da`: `Packaging_Type__c` → `Packaging_Type_Short_Name__c` (text field); deferred Type__c + Packaging_Type__c pending record type assignment
   - `03-distda`: `Location_Type__c` → `Type__c`; `Location_Code__c` stores raw dist ID (max 5 chars, not prefixed key)
   - `05-outda`: Full Market crosswalk remapped to match `ohfy__Market__c` restricted picklist values (also synced to shared/constants.js)
-- [ ] Verify stale cleanup queries (Script 09) return expected records after multi-file run
+- [x] Verify stale cleanup queries (Script 09) return expected records after multi-file run
+  - Added Placement__c as 5th cleanup target (simplified query — file date only, no from/to window)
+  - Added Placement__c to purge-vip-data.sh
+  - Verified against ROS2 sandbox: load with file-date 2026-04-08 → stale queries detect all records; re-load with 2026-04-09 → stale counts drop to 0
+  - Note: Each file type has its own from/to window (SLSDA=daily, CTLDA=monthly) — Tray workflow calls Script 09 per file type with matching dates
 
 ### Phase 5b: Account Model Refinement (2026-04-10)
 - [x] **Supplier perspective clarified:** ROS is a supplier. Distributors/wholesalers = Customers (who the supplier sells to). Retailers = Distributed Customers (who the supplier's customer sells to).

--- a/integrations/vip-srs/scripts/09-cleanup-stale.js
+++ b/integrations/vip-srs/scripts/09-cleanup-stale.js
@@ -33,6 +33,16 @@ var CLEANUP_TARGETS = [
     toDateField: 'VIP_To_Date__c'
   },
   {
+    sobject: NS + 'Placement__c',
+    externalIdField: 'VIP_External_ID__c',
+    prefix: 'PLC',
+    fileDateField: 'VIP_File_Date__c',
+    // Placement has no From/To date fields — one record per Account×Item,
+    // rebuilt each run. Stale = older file date for this distributor.
+    fromDateField: null,
+    toDateField: null
+  },
+  {
     sobject: NS + 'Inventory_History__c',
     externalIdField: 'VIP_External_ID__c',
     prefix: 'IVH',
@@ -63,19 +73,25 @@ var CLEANUP_TARGETS = [
 // =============================================================================
 
 function buildStaleQuery(target, distId, currentFileDate, fromDate, toDate) {
-  return 'SELECT Id FROM ' + target.sobject +
-    ' WHERE ' + target.fileDateField + ' < ' + currentFileDate +
-    ' AND ' + target.fromDateField + ' >= ' + fromDate +
-    ' AND ' + target.toDateField + ' <= ' + toDate +
-    " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+  var sql = 'SELECT Id FROM ' + target.sobject +
+    ' WHERE ' + target.fileDateField + ' < ' + currentFileDate;
+  if (target.fromDateField && target.toDateField) {
+    sql += ' AND ' + target.fromDateField + ' >= ' + fromDate +
+      ' AND ' + target.toDateField + ' <= ' + toDate;
+  }
+  sql += " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+  return sql;
 }
 
 function buildCountQuery(target, distId, currentFileDate, fromDate, toDate) {
-  return 'SELECT COUNT() FROM ' + target.sobject +
-    ' WHERE ' + target.fileDateField + ' < ' + currentFileDate +
-    ' AND ' + target.fromDateField + ' >= ' + fromDate +
-    ' AND ' + target.toDateField + ' <= ' + toDate +
-    " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+  var sql = 'SELECT COUNT() FROM ' + target.sobject +
+    ' WHERE ' + target.fileDateField + ' < ' + currentFileDate;
+  if (target.fromDateField && target.toDateField) {
+    sql += ' AND ' + target.fromDateField + ' >= ' + fromDate +
+      ' AND ' + target.toDateField + ' <= ' + toDate;
+  }
+  sql += " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+  return sql;
 }
 
 // =============================================================================

--- a/integrations/vip-srs/scripts/purge-vip-data.sh
+++ b/integrations/vip-srs/scripts/purge-vip-data.sh
@@ -168,11 +168,13 @@ echo "=== Phase 1: Transaction Records ==="
 echo ""
 
 if [[ -n "$DIST_ID" ]]; then
+  delete_records "ohfy__Placement__c" "Placements (PLC:${DIST_ID})" "VIP_External_ID__c LIKE 'PLC:${DIST_ID}:%'"
   delete_records "ohfy__Depletion__c" "Depletions (DEP:${DIST_ID})" "VIP_External_ID__c LIKE 'DEP:${DIST_ID}:%'"
   delete_records "ohfy__Allocation__c" "Allocations (ALC:${DIST_ID})" "VIP_External_ID__c LIKE 'ALC:${DIST_ID}:%'"
   delete_records "ohfy__Inventory_Adjustment__c" "Inventory Adjustments (IVA:${DIST_ID})" "VIP_External_ID__c LIKE 'IVA:${DIST_ID}:%'"
   delete_records "ohfy__Inventory_History__c" "Inventory History (IVH:${DIST_ID})" "VIP_External_ID__c LIKE 'IVH:${DIST_ID}:%'"
 else
+  delete_records "ohfy__Placement__c" "Placements (PLC:*)" "VIP_External_ID__c LIKE 'PLC:%'"
   delete_records "ohfy__Depletion__c" "Depletions (DEP:*)" "VIP_External_ID__c LIKE 'DEP:%'"
   delete_records "ohfy__Allocation__c" "Allocations (ALC:*)" "VIP_External_ID__c LIKE 'ALC:%'"
   delete_records "ohfy__Inventory_Adjustment__c" "Inventory Adjustments (IVA:*)" "VIP_External_ID__c LIKE 'IVA:%'"


### PR DESCRIPTION
## Summary
Add Placement__c to Script 09 stale cleanup and purge script. Verified stale cleanup queries end-to-end against the ROS2 sandbox — completes the last remaining Phase 5 item.

## Related Issues
Relates to VIP SRS supplier integration (Shipyard/ROS2)

## Type of Change
- [x] Feature (new capability)
- [ ] Bug fix (corrects an issue)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Data model change
- [ ] CI/CD / Infrastructure
- [ ] Test

## Changes Made
- Added `Placement__c` as 5th target in `09-cleanup-stale.js` with simplified stale query (file date only, no from/to window — one record per Account×Item, rebuilt each run)
- Updated query builders to conditionally include from/to date filters (null-safe for Placement)
- Added `Placement__c` to `purge-vip-data.sh` Phase 1 (leaf records)
- Checked off Phase 5 stale cleanup verification in ROADMAP.md with details

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Test coverage maintained or improved

Verified against ROS2 sandbox:
1. Loaded data with `--file-date 2026-04-08` → stale queries with future date detect all 13 records (5 DEP, 5 PLC, 3 ALC)
2. Re-loaded with `--file-date 2026-04-09` → stale counts drop to 0
3. Purge script successfully cleaned all 307 VIP records from sandbox

## Documentation
- [x] MD documentation updated
- [ ] DOCX generated
- [ ] Demo HTML updated
- [ ] N/A - no doc changes needed

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] No new warnings introduced
- [ ] Linked to issue(s)
- [ ] Labels applied