### PR TITLE
fix(ci): exclude skipped runs from health audit pass rate

### DIFF
--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -241,15 +241,16 @@ jobs:
           # Get all unique workflow names from recent runs
           WORKFLOWS=$(gh run list --limit 100 --json workflowName --jq '[.[].workflowName] | unique | .[]' 2>/dev/null)
 
-          echo "| Workflow | Runs | Passed | Failed | Rate |" >> /tmp/report.md
-          echo "|----------|------|--------|--------|------|" >> /tmp/report.md
+          echo "| Workflow | Runs | Passed | Failed | Skipped | Rate |" >> /tmp/report.md
+          echo "|----------|------|--------|--------|---------|------|" >> /tmp/report.md
 
           while IFS= read -r wf; do
             [ -z "$wf" ] && continue
 
-            TOTAL=$(gh run list --workflow "$wf" --limit 20 --json conclusion --jq 'length' 2>/dev/null || echo "0")
+            TOTAL=$(gh run list --workflow "$wf" --limit 20 --json conclusion --jq '[.[] | select(.conclusion == "success" or .conclusion == "failure")] | length' 2>/dev/null || echo "0")
             PASSED=$(gh run list --workflow "$wf" --limit 20 --json conclusion --jq '[.[] | select(.conclusion == "success")] | length' 2>/dev/null || echo "0")
             FAILED=$(gh run list --workflow "$wf" --limit 20 --json conclusion --jq '[.[] | select(.conclusion == "failure")] | length' 2>/dev/null || echo "0")
+            SKIPPED=$(gh run list --workflow "$wf" --limit 20 --json conclusion --jq '[.[] | select(.conclusion == "skipped")] | length' 2>/dev/null || echo "0")
 
             if [ "$TOTAL" -gt 0 ]; then
               RATE=$(( PASSED * 100 / TOTAL ))
@@ -266,7 +267,7 @@ jobs:
               ICON="🟡"
             fi
 
-            echo "| $ICON $wf | $TOTAL | $PASSED | $FAILED | ${RATE}% |" >> /tmp/report.md
+            echo "| $ICON $wf | $TOTAL | $PASSED | $FAILED | $SKIPPED | ${RATE}% |" >> /tmp/report.md
           done <<< "$WORKFLOWS"
 
           echo "" >> /tmp/report.md


### PR DESCRIPTION
## Summary
- Fix CI Watchdog health audit counting "skipped" runs against pass rate, causing false positives
- `TOTAL` now only counts runs with `success` or `failure` conclusions (excludes `skipped`, `cancelled`, etc.)
- Added "Skipped" column to health report table for transparency

Fixes #88

## Root cause
Workflows like Dependabot Auto-Merge, KB Writer, and CI Watchdog itself legitimately skip most runs when their job conditions don't match (e.g., PR author isn't dependabot, issue label isn't `kb-approved`). These skipped runs were being counted in the denominator, tanking reported pass rates.

## Note
Repo Watchers (`ANTHROPIC_API_KEY`, `SLACK_WEBHOOK_URL`) still needs secrets configured in GitHub Settings > Secrets to pass on next run.

## Test plan
- [x] Validated jq filter locally — correctly excludes skipped conclusions from count
- [ ] After merge, trigger health audit via `workflow_dispatch` or wait for Monday 9am UTC cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)