### PR TITLE
feat(vip-srs): add Placement__c fields, Account rep codes, Inventory fix, and platform docs

### DIFF
--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/Account/fields/VIP_Salesman1__c.field-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/Account/fields/VIP_Salesman1__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/09/metadata">
+    <fullName>VIP_Salesman1__c</fullName>
+    <description>Distributor primary sales rep code from VIP OUTDA (ROSM1). Not Shipyard's own rep — see Account.Sales_Rep__c for that.</description>
+    <externalId>false</externalId>
+    <label>VIP Distributor Rep 1</label>
+    <length>8</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/Account/fields/VIP_Salesman2__c.field-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/Account/fields/VIP_Salesman2__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/09/metadata">
+    <fullName>VIP_Salesman2__c</fullName>
+    <description>Distributor secondary sales rep code from VIP OUTDA (ROSM2). Not Shipyard's own rep — see Account.Sales_Rep__c for that.</description>
+    <externalId>false</externalId>
+    <label>VIP Distributor Rep 2</label>
+    <length>8</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/permissionsets/VIP_SRS_Integration.permissionset-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/permissionsets/VIP_SRS_Integration.permissionset-meta.xml
@@ -123,4 +123,14 @@
         <field>Contact.External_ID__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.VIP_Salesman1__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.VIP_Salesman2__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
 </PermissionSet>

--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/profiles/Admin.profile-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/profiles/Admin.profile-meta.xml
@@ -120,4 +120,14 @@
         <field>Contact.External_ID__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.VIP_Salesman1__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.VIP_Salesman2__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
 </Profile>

--- a/customers/shipyard/known-issues.md
+++ b/customers/shipyard/known-issues.md
@@ -35,6 +35,16 @@ Running log of known issues, workarounds, and resolutions for this customer.
 - **Workaround:** AccountSource is not a restricted picklist, so the API accepts 'VIP SRS' as a value. However, it won't appear in picklist dropdowns until added.
 - **Description:** The VIP SRS integration sets `AccountSource = 'VIP SRS'` for traceability. The value doesn't exist in the org's picklist. Recommended: add 'VIP SRS' to the AccountSource picklist values via Setup > Object Manager > Account > Fields > Account Source.
 
+### ~~Inventory "Duplicate Record Blocked" validation rule (ROS2)~~ RESOLVED
+- **Severity:** High
+- **Resolved:** 2026-04-13
+- **Fix:** Three-layer pre-query pattern implemented in `e2e-sandbox-runner.js` + `06-invda-inventory.js`:
+  1. **Lazy pre-query:** Runs after Phase 1 (not at startup) so Items have VIP_External_ID__c stamped. Queries existing Inventory by Item/Location relationships, builds VIP key → SF record ID map.
+  2. **Batch-stamp:** PATCHes VIP_External_ID__c on ALL 264 existing Inventory records so History/Adjustment children can reference any of them by external ID.
+  3. **Master-detail strip:** When PATCHing existing records by SF ID, removes `ohfy__Item__r` and `ohfy__Location__r` from body (master-detail, read-only on update).
+- **Result:** 264 stamped, 12 inventory updated, 489 history created, 8 adjustments created — 0 failures.
+- **For Tray (Phase 6):** Pre-query becomes a SOQL connector step before the Script 06 connector. Same pattern, Tray-native.
+
 ### ohfy__Market__c restricted picklist gaps
 - **Severity:** Low
 - **Affected area:** Integration — Account (Outlet) upserts

--- a/customers/shipyard/notes.md
+++ b/customers/shipyard/notes.md
@@ -4,6 +4,51 @@ Running notes from debugging sessions, design decisions, and gotchas.
 
 <!-- Add entries with dates. Most recent first. -->
 
+## 2026-04-13 — E2E Data Load + Three Enhancements
+
+Re-ran full VIP SRS E2E pipeline against ROS2 sandbox with `--file-date 2026-04-13`. Implemented three enhancements and fixed the Inventory duplicate validation blocker.
+
+**Prerequisites:**
+- Finished Good RT exists (`012am0000050BVKAA2`)
+- Transformation_Setting__c recreated: Each → Fluid Ounce(s), Volume, Beer (`a1FWF000001SLXB2A4`)
+
+**Enhancements implemented:**
+1. **Placement fields:** Added `Is_New_Placement__c = true` + `Lost_Placement_After_Days__c = 60` to Script 07b. Formula fields auto-compute: Days_Since_Last_Order (10), Lost_Placement_Date (2026-06-02).
+2. **Account rep codes:** Deployed `VIP_Salesman1__c` + `VIP_Salesman2__c` (Text(8)) to ROS2. Mapped in Script 05, filtering `999`/`HOUSE`. These are distributor rep codes (ROSM1/ROSM2), NOT supplier reps.
+3. **Inventory fix:** Three-layer pre-query pattern (see below).
+
+**Final results (after all fixes):**
+
+| Phase | Object | Count | Status |
+|-------|--------|-------|--------|
+| 1 | Account (Chains CHN:*) | 12 | ✅ create / ❌ update (AccountTrigger) |
+| 1 | Item (ITM:*) | 63 | ✅ |
+| 1 | Location (LOC:*) | 12 | ✅ |
+| 2 | Item Enrichment | 95 | ✅ |
+| 2 | Account (Outlets ACT:*) | 27 | ✅ VIP_Salesman1__c populated |
+| 2 | Contact (CON:*) | 25 | ✅ |
+| 3 | Inventory stamp | 264 | ✅ VIP_External_ID__c batch-stamped |
+| 3 | Inventory (IVT:*) | 12 | ✅ updated via PATCH-by-ID |
+| 3 | Inventory History (IVH:*) | 485 | ✅ |
+| 3 | Inventory Adjustments (IVA:*) | 5 | ✅ |
+| 4 | Depletion (DEP:*) | 40 | ✅ |
+| 4 | Placement (PLC:*) | 40 | ✅ Is_New_Placement + Lost_Placement_After_Days |
+| 4 | Allocation (ALC:*) | 23 | ✅ |
+
+- **Phase 3+4 total: 612 succeeded, 0 failures**
+- Phase 1 Chain Banner UPDATES fail (AccountTriggerMethods — pre-existing known issue). Creates work fine.
+
+**Inventory fix: Three-layer pre-query pattern**
+The managed package has a "Duplicate Record Blocked" validation rule on Inventory__c. ROS2 has 264 pre-existing records. Fix:
+1. **Lazy pre-query** — runs after Phase 1 stamps VIP_External_ID__c on Items (not at startup, where it finds 0)
+2. **Batch-stamp** — PATCHes VIP_External_ID__c on all 264 existing records so History/Adjustments can reference them
+3. **Master-detail strip** — removes Item__r/Location__r from PATCH body (read-only on update)
+
+**Key decision: ohfy__Placement__c IS the right object**
+- Managed object with 59+ fields including formula fields for CSO features (new placement detection, reorder alerts, volume tracking)
+- `ohfy__Account_Item__c` exists in source-index but has 0 deployed fields in ROS2 — not the right choice
+- CSO rep/territory/commission features (Territory__c, Goal__c, Goal_Tracking__c) exist as managed objects — may be leveraged later
+
 ## 2026-04-13 — CSO Requirements: Sales Rep Tracking & Commission System
 
 Email from ROS chief sales officer outlining core requirements for a rep tracking and commission system built on VIP data.

--- a/integrations/vip-srs/ROADMAP.md
+++ b/integrations/vip-srs/ROADMAP.md
@@ -103,6 +103,18 @@
 - [x] Script 09 (cleanup): Added `countQuery` (SELECT COUNT()) per target for sanity check — Tray workflow should compare stale count vs upsert count before deleting; if stale > upserted, skip delete (possible truncated/partial file)
 - [x] **Key decision documented:** Invoice__c/Invoice_Item__c is NOT built from VIP data. VIP SLSDA = distributor→retailer depletions (Depletion__c + Placement__c). Invoice objects are for supplier→distributor invoicing — a separate data source entirely.
 
+### Phase 5e: Enhanced E2E Validation (2026-04-13)
+- [x] **Placement__c enhancements:** Added `Is_New_Placement__c = true` + `Lost_Placement_After_Days__c = 60` to Script 07b. Formula fields auto-compute: `Days_Since_Last_Order__c` (10 days), `Lost_Placement_Date__c` (Last_Sold + 60).
+- [x] **Account distributor rep codes:** Created + deployed `VIP_Salesman1__c` and `VIP_Salesman2__c` (Text(8)) on Account with FLS. Mapped in Script 05, filtering out `999` (unassigned) and `HOUSE` (house account). These are distributor rep codes (ROSM1/ROSM2), NOT supplier reps.
+- [x] **Inventory "Duplicate Record Blocked" fix:** Three-layer pre-query pattern in e2e-sandbox-runner.js + Script 06:
+  1. Lazy pre-query (runs after Phase 1 stamps VIP_External_ID__c on Items, not at startup)
+  2. Batch-stamp VIP_External_ID__c on all 264 existing Inventory records (so History/Adjustments can reference them)
+  3. Script 06 PATCHes existing records by SF ID, stripping master-detail fields (Item__r, Location__r)
+- [x] Phase 3 result: 264 stamped + 12 inv + 489 history + 8 adjustments = 509 succeeded, 0 failed
+- [x] Phase 4 result: 40 depletions + 40 placements + 23 allocations = 103 succeeded, 0 failed
+- [x] **Full E2E: 612 records, 0 failures** (Phase 3 + Phase 4)
+- [x] Phase 1 Chain Banner UPDATES still blocked by AccountTriggerMethods (pre-existing known issue; creates work fine)
+
 ## Next Up
 
 ### Phase 6: Tray.io Project Build
@@ -144,6 +156,9 @@
 | **Placement__c keyed by Account×Item** (not per invoice line) | One placement per distributor+account+item. Aggregated from SLSDA rows: earliest/latest sold dates, latest price/qty. External ID: `PLC:{DistId}:{AcctNbr}:{SuppItem}` |
 | **No Invoice__c from VIP data** | VIP SLSDA = distributor→retailer depletions (Depletion__c + Placement__c). Invoice__c is for supplier→distributor invoicing — different data source, not from VIP files |
 | **VIP_File_Date__c = date of pipeline run** | Not derived from file contents. FromDate/ToDate capture the file's reporting window. File date stamps when a record was last refreshed, enabling stale cleanup. |
+| **ohfy__Placement__c is the right object** (not Account_Item__c) | Managed object with 59+ fields including formula fields for CSO features. Account_Item__c exists in source-index but has 0 deployed fields in ROS2. |
+| **VIP Salesman1/2 = distributor rep codes** (not supplier reps) | OUTDA Salesman1/Salesman2 are ROSM1/ROSM2 (distributor employee codes). Stored as `VIP_Salesman1__c`/`VIP_Salesman2__c` text fields on Account. Supplier reps are SF Users, manually assigned in Ohanafy. |
+| **Lost_Placement_After_Days = 60** | CSO requirement for reorder alert window. Feeds formula: `Lost_Placement_Date__c = Last_Sold_Date + 60`. After that date, `Days_Since_Last_Order > 60` flags it as a lost placement. |
 
 ## Gotchas
 
@@ -162,3 +177,7 @@
 13. **AccountSource 'VIP SRS' not in picklist:** The field is not restricted so the API accepts it, but the value won't appear in picklist dropdowns until added via Setup.
 14. **Item lookup filter chain on Depletion__c.Item__c:** The lookup filter (`optionalFilter: false`) requires the Item to have: (a) Finished Good record type, (b) `Type__c = 'Finished Good'`, (c) `UOM__c` set (e.g., 'US Count'), (d) `Packaging_Type__c` set (dependent on UOM, e.g., 'Each'), and (e) a `Transformation_Setting__c` record linking the Packaging_Type to a Volume UOM (e.g., Each → Fluid Ounce(s)). Missing any of these causes `FIELD_FILTER_VALIDATION_EXCEPTION`. Script 02 must ensure items meet all prerequisites before depletions can load.
 15. **Placement__c master-detail fields are create-only:** `ohfy__Account__c` and `ohfy__Item__c` are master-detail and can only be set on initial create (updateable=false). Use `__r` relationship syntax in Composite API body. On subsequent upserts, the API silently ignores these fields — the record stays parented to the original Account×Item.
+16. **Inventory pre-query must run AFTER Phase 1:** The pre-query matches existing Inventory records by `Item__r.VIP_External_ID__c LIKE 'ITM:%'`. But Items don't have VIP_External_ID__c until Phase 1 stamps them. Running the pre-query at pipeline startup finds 0 records. Use lazy execution — trigger when Phase 3 starts.
+17. **ALL existing Inventory records need VIP_External_ID__c batch-stamped:** History and Adjustment rows reference parent Inventory by VIP_External_ID__c. Even if the Inventory transform only outputs 12 records, History may reference hundreds of different DistId:Item combos. Stamp VIP_External_ID__c on ALL existing records (264 in ROS2) before loading children, not just the records in your current file.
+18. **Inventory__c master-detail fields are read-only on update:** When PATCHing an existing Inventory record by SF record ID, strip `ohfy__Item__r` and `ohfy__Location__r` from the request body. These are master-detail (create-only) fields. Including them returns `INVALID_FIELD_FOR_INSERT_UPDATE`.
+19. **Item_Line__c has no upsert key:** Created via `sf data create record` / direct insert. Re-runs of ITM2DA create duplicate Item_Line__c records. Minor issue for sandbox testing; for production, add a dedup pre-check query.

--- a/integrations/vip-srs/docs/VIP_AGENT_HANDOFF.md
+++ b/integrations/vip-srs/docs/VIP_AGENT_HANDOFF.md
@@ -457,7 +457,8 @@ Enriches Item records already created from ITM2DA. Upserts on the same `VIP_Exte
 | ClassOfTrade | `06` | Account.`Market__c` | Crosswalk (Section 7.1) | |
 | ClassOfTrade | `06` | Account.`Premise_Type__c` | Derived: 01-19=Off, 21-43=On | |
 | ChainStatus | `I` | Account.`Retail_Type__c` | `C`->`Chain`, `I`->`Independent` | |
-| Salesman1 | `900` | Account.`Sales_Rep__c` | Lookup User by rep code | Requires mapping table |
+| Salesman1 | `900` | Account.`VIP_Salesman1__c` | Direct (Text). Filter: skip `999`, `HOUSE` | Distributor rep code, NOT supplier rep |
+| Salesman2 | `` | Account.`VIP_Salesman2__c` | Direct (Text) | Distributor rep code, NOT supplier rep |
 | Store | `` | Account.`Store_Number__c` | Direct | |
 | Status | `A` | Account.`Is_Active__c` | `A`->true, `I`/`O`->false | |
 | License | `WSL2100120` | Account.`ABC_License_Number__c` | Direct | |
@@ -523,23 +524,31 @@ One record per SLSDA row after filtering.
 | *(composite)* | -- | Invoice_Item__c.`VIP_External_ID__c` | `INL:{DistId}:{InvoiceNbr}:{AcctNbr}:{SuppItem}:{UOM}` | Upsert key |
 | *(composite)* | -- | Invoice_Item__c.`Invoice__c` | Lookup `INV:{DistId}:{InvoiceNbr}:{InvoiceDate}` | Parent invoice |
 
-#### 5.6c Distributor_Placement__c
+#### 5.6c ohfy__Placement__c (Account × Item aggregation)
 
-Same source rows, mapped to the depletion tracking object.
+SLSDA rows aggregated into one record per Account+Item combination. Tracks placement lifecycle (new distribution, reorder alerts, volume).
+
+**Note:** This is the managed `ohfy__Placement__c` object (59+ fields), NOT `ohfy__Account_Item__c` or a custom `Distributor_Placement__c`. Master-detail to Account and Item (create-only).
 
 | Derived From | Ohanafy Object.Field | Transform | Notes |
 |-------------|---------------------|-----------|-------|
-| *(composite)* | `Integration_ID__c` | `DPL:{DistId}:{InvoiceNbr}:{AcctNbr}:{SuppItem}:{UOM}` | Upsert key |
-| AcctNbr | `ohanafy__Customer__c` | Lookup `ACT:{DistId}:{AcctNbr}` | |
-| SuppItem | `ohanafy__Item__c` | Lookup `ITM:{SuppItem}` | |
-| Qty | `ohanafy__Quantity__c` | Direct | Negative = return |
-| InvoiceDate | `ohanafy__Date__c` | `YYYYMMDD` -> `YYYY-MM-DD` | |
-| NetPrice | `Price__c` | Direct | |
-| FromDate | `VIP_From_Date__c` | `YYYYMMDD` -> `YYYY-MM-DD` | For stale cleanup |
-| ToDate | `VIP_To_Date__c` | `YYYYMMDD` -> `YYYY-MM-DD` | For stale cleanup |
-| *(filename)* | `VIP_File_Date__c` | `N20260408` -> `2026-04-08` | For stale cleanup |
+| *(composite)* | `VIP_External_ID__c` | `PLC:{DistId}:{AcctNbr}:{SuppItem}` | Upsert key (one per Account×Item) |
+| AcctNbr | `ohfy__Account__r` | Lookup `ACT:{DistId}:{AcctNbr}` | Master-detail, create-only |
+| SuppItem | `ohfy__Item__r` | Lookup `ITM:{SuppItem}` | Master-detail, create-only |
+| *(aggregated)* | `ohfy__First_Sold_Date__c` | MIN(InvoiceDate) across all rows for this Account+Item | |
+| *(aggregated)* | `ohfy__Last_Sold_Date__c` | MAX(InvoiceDate) across all rows for this Account+Item | |
+| *(latest row)* | `ohfy__Last_Purchase_Date__c` | InvoiceDate from latest row | |
+| *(latest row)* | `ohfy__Last_Purchase_Quantity__c` | Qty from latest row | |
+| *(latest row)* | `ohfy__Last_Invoice_Price__c` | NetPrice from latest row | |
+| -- | `ohfy__Is_Active__c` | Hardcode `true` | Active placement |
+| -- | `ohfy__Is_New_Placement__c` | Hardcode `true` | Flags recent activity |
+| -- | `ohfy__Lost_Placement_After_Days__c` | Hardcode `60` | CSO reorder alert threshold (days) |
+| *(filename)* | `VIP_File_Date__c` | Date of pipeline run | For stale cleanup |
 
-**Negative quantities:** Rows with negative Qty are credits/returns. Load with negative quantity. Suffix the Integration_ID with `:NEG` for Distributor_Placement__c.
+**Formula fields (auto-computed, not set by pipeline):**
+- `ohfy__Days_Since_Last_Order__c` = `TODAY() - Last_Sold_Date__c`
+- `ohfy__Lost_Placement_Date__c` = `Last_Sold_Date__c + Lost_Placement_After_Days__c`
+- `ohfy__Item_Subtype__c` = `TEXT(Item__r.Package_Type__c)`
 
 ---
 
@@ -635,7 +644,7 @@ Keys use only **immutable business identifiers**. No quantities, prices, or name
 | Inventory_History__c | `IVH` | DistId, SupplierItem, PostingDate, UOM | `IVH:FL01:102312102:20260403:C` |
 | Inventory_Adjustment__c | `IVA` | DistId, SupplierItem, TransCode, TransDate, UOM | `IVA:FL01:102312102:20:20260403:C` |
 | Allocation__c | `ALC` | DistId, SupplierItem, ControlDate, UOM | `ALC:FL01:102312102:202604:C` |
-| Distributor_Placement__c | `DPL` | DistId, InvoiceNbr, AcctNbr, SuppItem, UOM | `DPL:FL01:0699528:21159:102312102:C` |
+| ohfy__Placement__c | `PLC` | DistId, AcctNbr, SuppItem | `PLC:FL01:21159:102312102` |
 
 ### Design Principles
 
@@ -962,13 +971,13 @@ After each run, generate:
 
 ## 13. Open Questions
 
-1. **Distributor_Placement__c vs Invoice_Item__c** -- Load SLSDA to both, or just one? Existing integrations use Distributor_Placement for depletion reporting. The Invoice model gives richer financial data. Recommend both.
+1. ~~**Distributor_Placement__c vs Invoice_Item__c**~~ **RESOLVED (2026-04-13):** Use `ohfy__Placement__c` (managed, 59+ fields) for Account×Item aggregation. Use `ohfy__Depletion__c` for per-transaction records. Invoice__c is for supplier→distributor billing — separate data source, not from VIP files. No Invoice__c from VIP data.
 
 2. **MTD inventory codes** -- TransCodes 50-59 are month-to-date aggregates that overlap daily codes 20-41. Loading both would double-count. Recommend skipping MTD.
 
 3. **Historical backfill** -- Sample data covers 11 business days. For a new customer, do we backfill all historical data or start from a cutover date?
 
-4. **Sales Rep mapping** -- VIP provides rep codes (`056`, `SB4`, `SS6`). Ohanafy needs Salesforce User IDs. Requires a manual mapping table per distributor.
+4. ~~**Sales Rep mapping**~~ **PARTIALLY RESOLVED (2026-04-13):** VIP `Salesman1`/`Salesman2` are **distributor rep codes** (ROSM1/ROSM2), NOT supplier reps. Stored as `VIP_Salesman1__c`/`VIP_Salesman2__c` text fields on Account. Filtered: `999` (unassigned) and `HOUSE` excluded. Supplier's own reps are Salesforce Users, manually assigned in Ohanafy — not from VIP data.
 
 5. **Market picklist values** -- The Class of Trade crosswalk (Section 7.1) maps to Market values that may not exist in the target org's `Account_Sub_Type` value set. Need to validate and add missing values.
 

--- a/integrations/vip-srs/scripts/05-outda-accounts.js
+++ b/integrations/vip-srs/scripts/05-outda-accounts.js
@@ -187,6 +187,16 @@ function transformAccount(row, distId) {
   var license = clean(row.License);
   if (license) record.ohfy__ABC_License_Number__c = license;
 
+  // Distributor rep codes (ROSM1/ROSM2) — NOT Shipyard's own reps
+  var salesman1 = clean(row.Salesman1);
+  if (salesman1 && salesman1 !== '999' && salesman1 !== 'HOUSE') {
+    record.VIP_Salesman1__c = salesman1;
+  }
+  var salesman2 = clean(row.Salesman2);
+  if (salesman2) {
+    record.VIP_Salesman2__c = salesman2;
+  }
+
   if (isDist) {
     // --- Distributor/Wholesaler: who the supplier sells to ---
     record.Type = 'Customer';

--- a/integrations/vip-srs/scripts/06-invda-inventory.js
+++ b/integrations/vip-srs/scripts/06-invda-inventory.js
@@ -273,7 +273,12 @@ exports.step = function(input) {
     }
   });
 
-  // 3. BATCH — Inventory__c (uses unmanaged VIP_External_ID__c)
+  // 3. BATCH — Inventory__c
+  // If existingInventoryMap is provided, match by Item VIP_External_ID__c + Location
+  // to find pre-existing records and PATCH by record ID (stamps VIP_External_ID__c).
+  // This avoids the managed "Duplicate Record Blocked" validation rule.
+  var existingMap = input.existingInventoryMap || {};
+
   var inventoryChunks = chunkArray(inventoryRecords);
   var inventoryBatches = inventoryChunks.map(function(chunk) {
     return {
@@ -283,6 +288,26 @@ exports.step = function(input) {
         Object.keys(record).forEach(function(key) {
           if (key !== 'VIP_External_ID__c') body[key] = record[key];
         });
+
+        // Check if a pre-existing Inventory record matches this Item+Location
+        var existingId = existingMap[extId];
+        if (existingId) {
+          // PATCH by record ID — update existing record and stamp VIP_External_ID__c.
+          // Strip master-detail relationship fields (Item__r, Location__r) — they're
+          // read-only on update and already correct on the existing record.
+          delete body[NS + 'Item__r'];
+          delete body[NS + 'Location__r'];
+          body.VIP_External_ID__c = extId;
+          return {
+            method: 'PATCH',
+            url: '/services/data/' + SF_CONFIG.apiVersion + '/sobjects/' +
+              NS + 'Inventory__c/' + existingId,
+            referenceId: 'inv_' + idx,
+            body: body
+          };
+        }
+
+        // Normal upsert by VIP_External_ID__c (for new records or re-runs)
         return {
           method: 'PATCH',
           url: '/services/data/' + SF_CONFIG.apiVersion + '/sobjects/' +

--- a/integrations/vip-srs/scripts/07b-slsda-placements.js
+++ b/integrations/vip-srs/scripts/07b-slsda-placements.js
@@ -138,6 +138,14 @@ function transformPlacement(entry) {
   // Active — has sales activity
   record[NS + 'Is_Active__c'] = true;
 
+  // New placement flag — set true on every upsert (placement has recent activity)
+  record[NS + 'Is_New_Placement__c'] = true;
+
+  // Lost placement threshold (days) — CSO requires 60-day reorder alert window
+  // Feeds formula: Lost_Placement_Date__c = Last_Sold_Date + 60
+  // Days_Since_Last_Order__c = TODAY() - Last_Sold_Date (auto-formula)
+  record[NS + 'Lost_Placement_After_Days__c'] = 60;
+
   // Stale cleanup date
   if (entry.fileDate) record.VIP_File_Date__c = entry.fileDate;
 

--- a/integrations/vip-srs/scripts/e2e-sandbox-runner.js
+++ b/integrations/vip-srs/scripts/e2e-sandbox-runner.js
@@ -379,6 +379,64 @@ if (FINISHED_GOOD_RT_ID) {
 }
 console.log('');
 
+// Pre-query existing Inventory records to handle "Duplicate Record Blocked" validation rule.
+// Maps VIP inventory key (IVT:{DistId}:{SuppItem}) → existing Salesforce record ID.
+// NOTE: Runs lazily before Phase 3 (not at startup) because Phase 1 must stamp
+// VIP_External_ID__c on Items first for the SOQL relationship filter to match.
+var existingInventoryMap = {};
+var _NS = 'ohfy__';
+var _inventoryPreQueryDone = false;
+
+function runInventoryPreQuery() {
+  if (_inventoryPreQueryDone) return;
+  _inventoryPreQueryDone = true;
+  console.log('Pre-query: Checking for existing Inventory records...');
+  var invRecords = sfQuery(
+    "SELECT Id, " + _NS + "Item__r." + _NS + "VIP_External_ID__c, " +
+    _NS + "Location__r.VIP_External_ID__c " +
+    "FROM " + _NS + "Inventory__c " +
+    "WHERE " + _NS + "Item__r." + _NS + "VIP_External_ID__c LIKE 'ITM:%'"
+  );
+  invRecords.forEach(function(r) {
+    var itemRef = r[_NS + 'Item__r'];
+    var locRef = r[_NS + 'Location__r'];
+    var itemExtId = itemRef ? itemRef[_NS + 'VIP_External_ID__c'] : null;
+    var locExtId = locRef ? locRef['VIP_External_ID__c'] : null;
+    if (itemExtId && locExtId) {
+      var distId = locExtId.replace('LOC:', '');
+      var suppItem = itemExtId.replace('ITM:', '');
+      var vipKey = 'IVT:' + distId + ':' + suppItem;
+      existingInventoryMap[vipKey] = r.Id;
+    }
+  });
+  var mapKeys = Object.keys(existingInventoryMap);
+  console.log('  Found ' + mapKeys.length + ' existing Inventory records with VIP items');
+
+  // Batch-stamp VIP_External_ID__c on all existing records that don't have it yet.
+  // This ensures History/Adjustment rows can reference ANY existing Inventory by VIP key.
+  if (mapKeys.length > 0) {
+    console.log('  Stamping VIP_External_ID__c on existing Inventory records...');
+    var stampBatches = [];
+    for (var si = 0; si < mapKeys.length; si += 25) {
+      var chunk = mapKeys.slice(si, si + 25);
+      stampBatches.push({
+        compositeRequest: chunk.map(function(vipKey, idx) {
+          return {
+            method: 'PATCH',
+            url: '/services/data/' + API_VERSION + '/sobjects/' +
+              _NS + 'Inventory__c/' + existingInventoryMap[vipKey],
+            referenceId: 'stamp_' + idx,
+            body: { VIP_External_ID__c: vipKey }
+          };
+        })
+      });
+    }
+    var stampResult = sendBatches(stampBatches, 'Inventory stamp');
+    console.log('  Stamped: ' + stampResult.success + ' succeeded, ' + stampResult.fail + ' failed');
+  }
+  console.log('');
+}
+
 var totalSuccess = 0;
 var totalFail = 0;
 var stepResults = [];
@@ -416,6 +474,14 @@ PIPELINE.forEach(function(step) {
 
   // Inject record type IDs for item scripts
   if (FINISHED_GOOD_RT_ID) input.finishedGoodRecordTypeId = FINISHED_GOOD_RT_ID;
+
+  // Inject existing Inventory map for Script 06 (avoids duplicate validation rule)
+  if (step.script === '06-invda-inventory.js') {
+    runInventoryPreQuery();
+    if (Object.keys(existingInventoryMap).length > 0) {
+      input.existingInventoryMap = existingInventoryMap;
+    }
+  }
 
   var result;
   try {

--- a/integrations/vip-srs/shared/constants.js
+++ b/integrations/vip-srs/shared/constants.js
@@ -34,6 +34,10 @@ var SF_CONFIG = {
   namespacePrefix: 'ohfy'
 };
 
+// Placement threshold: days without a reorder before flagging as lost placement
+// CSO requirement: 60-day reorder alert window
+var LOST_PLACEMENT_DAYS = 60;
+
 // =============================================================================
 // 7.1 CLASS OF TRADE CROSSWALK
 // OUTDA.ClassOfTrade → Account.Market__c + Account.Premise_Type__c

--- a/knowledge-base/ohanafy/integration-points.md
+++ b/knowledge-base/ohanafy/integration-points.md
@@ -88,6 +88,52 @@
 | `lookup-maps.js` | Map/Set factories, status mapping |
 | `output-structuring.js` | Success/error envelopes, summaries |
 
+## Managed Package Data Loading Constraints
+
+Hard-won lessons from loading data into subscriber orgs with the Ohanafy managed package installed. These apply to ANY integration, not just VIP SRS.
+
+See `knowledge-base/ohanafy/objects/` for per-object details.
+
+### Master-detail fields are create-only
+
+Many managed objects (Inventory__c, Placement__c, Depletion__c) use master-detail relationships. These fields can only be set on INSERT, not UPDATE. Use `__r` relationship syntax in Composite API body. When updating existing records by SF ID, **strip master-detail fields from the PATCH body** or get `INVALID_FIELD_FOR_INSERT_UPDATE`.
+
+### External ID field names vary by object
+
+| Object | External ID Field | Managed? |
+|--------|------------------|----------|
+| Account | `ohfy__External_ID__c` | Yes |
+| Contact | `External_ID__c` | No |
+| Item__c | `ohfy__VIP_External_ID__c` | Yes |
+| Location__c | `VIP_External_ID__c` | No |
+| Inventory__c, History, Adjustment | `VIP_External_ID__c` | No |
+| Placement__c | `VIP_External_ID__c` | No |
+| Depletion__c | `VIP_External_ID__c` | No |
+| Allocation__c | `VIP_External_ID__c` | No |
+
+Never assume consistency — always check the field name per object.
+
+### Validation rules may block upserts
+
+The managed package has validation rules that enforce natural key uniqueness (e.g., Inventory__c blocks duplicate Item+Location combos). Standard upsert by external ID can INSERT when a record already exists under a different key, triggering the validation rule.
+
+**Pre-query pattern:** Query existing records by relationship fields (not external ID), build a map of external ID → SF record ID, then PATCH by SF record ID. Stamp the external ID on existing records so future upserts work normally.
+
+### AccountTrigger / ServiceLocator pattern
+
+`ohfy.AccountTrigger` fires on AfterUpdate and calls `AccountTriggerMethods` via ServiceLocator. If the implementation class is missing in the subscriber org:
+- **Inserts work** (first load succeeds)
+- **Updates fail** (re-upserts on same data fail with ServiceLocatorException)
+- Requires Ohanafy engineering to deploy the missing class
+
+### Restricted picklists vary by org and record type
+
+`ohfy__Market__c`, `ohfy__Packaging_Type__c`, and others are restricted picklists. Always describe the field via API before building crosswalks — values differ between orgs and record types. Generic human-friendly names (e.g., "Bar") fail if the org uses a different label (e.g., "Bars/Clubs/Taverns").
+
+### Item prerequisite chain for Depletion__c
+
+Depletion__c has a mandatory Item lookup filter requiring 5 prerequisites on the Item. See `knowledge-base/ohanafy/objects/depletion.md` for the full chain. This is the most common failure when loading depletions into a new org.
+
 ## Key Integration Principles
 
 1. **Tray-first** — always check existing Tray workflows before building new
@@ -97,3 +143,5 @@
 5. **Error envelope pattern** — structured success/error responses
 6. **Watermark/delta sync** — use Tray Data Storage for tracking last sync point
 7. **No credentials in code** — AWS Secrets Manager only
+8. **Pre-query before upsert** — when managed validation rules enforce natural key uniqueness, query existing records first
+9. **Load order matters** — reference data (Items, Locations) before enrichment before transactions; pre-queries must run after dependencies are stamped

--- a/knowledge-base/ohanafy/objects/README.md
+++ b/knowledge-base/ohanafy/objects/README.md
@@ -18,5 +18,10 @@ Per-object field-level knowledge learned from real org usage. This is the **huma
 
 ## Objects documented
 
+- [Account](account.md) — Standard object with ohfy triggers, record types, and picklist constraints
+- [ohfy__Depletion__c](depletion.md) — Distributor-to-retailer sales transactions (not invoices)
+- [ohfy__Inventory__c](inventory.md) — Current stock levels per Item per Location
+- [ohfy__Item__c](item.md) — Product master (SKUs) with record type gating and restricted picklists
 - [ohfy__Order__c](order.md) — Orders (sales, credits, transfers)
 - [ohfy__Order_Item__c](order-item.md) — Line items on orders
+- [ohfy__Placement__c](placement.md) — Account-by-Item tracking (new placements, reorder alerts, volume)

--- a/knowledge-base/ohanafy/objects/account.md
+++ b/knowledge-base/ohanafy/objects/account.md
@@ -1,0 +1,66 @@
+# Account (standard object with ohfy customizations)
+
+Standard Salesforce Account extended by the Ohanafy managed package with custom fields, record types, triggers, and picklists.
+
+## Quick facts
+
+- **Namespace:** Standard object with ohfy__ custom fields
+- **Triggers:** ohfy.AccountTrigger (managed, uses ServiceLocator pattern)
+- **External ID:** `ohfy__External_ID__c` (managed field)
+- **Key custom fields:** Market__c, Premise_Type__c, Retail_Type__c, Chain_Banner__c, Store_Number__c, Is_Active__c
+
+## AccountTrigger blocker
+
+`ohfy.AccountTrigger` fires on AfterUpdate and calls `AccountTriggerMethods` via the ServiceLocator pattern. In subscriber orgs where `AccountTriggerMethods` class is not deployed:
+
+- **INSERT succeeds** — AfterInsert handler may not call the missing class
+- **UPDATE fails** — `ServiceLocator.ServiceLocatorException: Invalid implementation class: AccountTriggerMethods`
+
+This means:
+- First data load (creates) works fine
+- Second data load (upserts = updates) fails on every Account record
+- **Hard blocker for daily sync idempotency** — Ohanafy engineering must deploy the missing class or update the ServiceLocator config
+
+### Workaround
+
+In Tray/pipeline, set `allOrNone=false` and log Account update errors separately. Account creates succeed; updates accumulate until the trigger is fixed.
+
+## Record types
+
+Record types affect field access, picklist values, and business logic:
+
+| Record Type | DeveloperName | Use Case |
+|-------------|---------------|----------|
+| Chain_Banner | `Chain_Banner` | Parent accounts for retail chains |
+| Customer | `Customer` | Supplier's direct buyer (distributor/wholesaler) |
+| Distributed_Customer | `Distributed_Customer` | Distributor's retail customer (bar, store, restaurant) |
+
+- **Integration user must have all needed record types assigned** on their profile
+- Chain Banners: set `ohfy__Is_Chain_Banner__c = true`, `Type = 'Chain Banner'`
+- Customers (supplier perspective): `Type = 'Customer'`, `ohfy__Retail_Type__c = 'Distributor'`
+- Distributed Customers: `Type = 'Distributed Customer'`, link to Chain_Banner via `ohfy__Chain_Banner__r`
+
+## Picklist gotchas
+
+### ohfy__Market__c (RESTRICTED)
+
+Restricted picklist — values vary by org. Always describe the field before building crosswalks. Not all source data values will have a match (e.g., 14 of 46 VIP Class of Trade codes have no matching picklist value: Military, E-Commerce, CBD/THC, etc.).
+
+### AccountSource (NOT restricted)
+
+The API accepts any string value. Custom values (e.g., `VIP SRS`) work for tagging but won't appear in picklist dropdowns until manually added via Setup.
+
+## External ID
+
+`ohfy__External_ID__c` is the managed external ID field. Note this is different from other objects:
+- Account: `ohfy__External_ID__c` (managed)
+- Contact: `External_ID__c` (unmanaged custom)
+- Most VIP objects: `VIP_External_ID__c` (unmanaged custom)
+
+Always check the field name per object — don't assume consistency.
+
+## Discovered in
+
+- VIP SRS Phase 5b (2026-04-10): AccountTrigger blocker discovered on Account re-upsert
+- VIP SRS Phase 5b (2026-04-10): Supplier perspective clarified (distributors = Customers, retailers = Distributed Customers)
+- VIP SRS Phase 5e (2026-04-13): AccountTrigger blocks Chain Banner UPDATES on second E2E run

--- a/knowledge-base/ohanafy/objects/depletion.md
+++ b/knowledge-base/ohanafy/objects/depletion.md
@@ -1,0 +1,59 @@
+# ohfy__Depletion__c
+
+Distributor-to-retailer sales transaction records. Represents sell-through data from distribution, NOT supplier-to-distributor invoices (that's Invoice__c).
+
+## Quick facts
+
+- **Namespace:** ohfy__
+- **Triggers:** DepletionTrigger (via DepletionTriggerService — before/after insert, update, delete)
+- **Key relationships:** Lookup to Item__c (with mandatory filter), Lookup to Account
+
+## Critical: Item lookup filter chain
+
+`ohfy__Item__c` has a mandatory, non-optional lookup filter. The referenced Item must have ALL of the following:
+
+1. **Finished Good record type** assigned
+2. **`ohfy__Type__c = 'Finished Good'`** explicitly set
+3. **`ohfy__UOM__c`** set (e.g., `US Count`)
+4. **`ohfy__Packaging_Type__c`** set (dependent picklist on UOM, e.g., `Each`)
+5. **`ohfy__Transformation_Setting__c`** record exists linking the Packaging_Type to a Volume UOM
+
+Missing ANY prerequisite causes `FIELD_FILTER_VALIDATION_EXCEPTION`. This is the most common failure mode when loading depletions into a new org.
+
+### Transformation_Setting__c setup
+
+- One record needed per Packaging_Type → Volume UOM mapping
+- Key field: `ohfy__Key__c` = `{PackagingType}-{VolumeUOM}` (e.g., `Each-Fluid Ounce(s)`)
+- Must exist BEFORE any Depletion records can reference the Item
+- These are not auto-created — they must be manually or programmatically seeded per org
+
+### Prerequisite load order
+
+```
+1. Create Transformation_Setting__c (if missing)
+2. Create/update Items with:
+   - RecordTypeId = Finished Good RT
+   - Type__c = 'Finished Good'
+   - UOM__c = 'US Count' (or org-specific value)
+   - Packaging_Type__c = 'Each' (or org-specific value)
+3. THEN load Depletion records
+```
+
+## Key fields
+
+| Field | Notes |
+|-------|-------|
+| `ohfy__Type__c` | Set to `'Sale'` for standard depletions — makes them visible in type-filtered reports |
+| `ohfy__Date__c` | Invoice/transaction date |
+| `ohfy__Quantity__c` | Quantity sold (negative = return/credit) |
+| `ohfy__Net_Amount__c` | Net dollar amount |
+
+## Depletion vs Invoice
+
+VIP/distribution data = distributor-to-retailer sales → **Depletion__c** (+ Placement__c for aggregation).
+Supplier-to-distributor billing → **Invoice__c / Invoice_Item__c** — completely separate data source, not from VIP files.
+
+## Discovered in
+
+- VIP SRS Phase 5c (2026-04-10): Discovered 5-prerequisite filter chain during E2E testing. Undocumented in managed package.
+- Item lookup filter is the #1 blocker when setting up a new customer org for depletion data.

--- a/knowledge-base/ohanafy/objects/inventory.md
+++ b/knowledge-base/ohanafy/objects/inventory.md
@@ -1,0 +1,55 @@
+# ohfy__Inventory__c
+
+Current stock levels per Item per Location. The junction object between Item and Location that tracks on-hand quantities.
+
+## Quick facts
+
+- **Namespace:** ohfy__
+- **Key relationships:** Master-detail to Item__c, Master-detail to Location__c
+- **Child objects:** Inventory_History__c, Inventory_Adjustment__c
+- **Validation rules:** "Duplicate Record Blocked" — prevents duplicate Item+Location combos
+
+## Integration constraints
+
+### Duplicate Record Blocked validation rule
+
+The managed package has a validation rule that prevents creating a second Inventory record for the same Item+Location combination. This means:
+
+- **Standard upsert by external ID will fail** if a record already exists for that Item+Location but doesn't have the external ID set. The upsert tries to INSERT (because the external ID doesn't match), and the validation rule blocks it.
+- **Pre-query pattern required:** Before loading Inventory, query existing records by Item/Location relationships, build a map of external ID → SF record ID, then PATCH by SF record ID instead of upserting.
+
+### Pre-query pattern (three layers)
+
+Any integration loading Inventory must implement this pattern:
+
+**1. Lazy timing:** The pre-query must run AFTER Items and Locations have external IDs stamped (e.g., after Phase 1 in a multi-phase pipeline). Running at pipeline startup finds 0 matches because the Items don't have external IDs yet.
+
+```sql
+SELECT Id, ohfy__Item__r.ohfy__VIP_External_ID__c,
+       ohfy__Location__r.VIP_External_ID__c
+FROM ohfy__Inventory__c
+WHERE ohfy__Item__r.ohfy__VIP_External_ID__c LIKE 'ITM:%'
+```
+
+**2. Batch-stamp all existing records:** History and Adjustment child records reference their parent Inventory by external ID. Even if your current file only produces N inventory records, the History rows may reference many more. Stamp external IDs on ALL existing Inventory records that match your Items/Locations — not just the ones in your current file.
+
+**3. Strip master-detail fields on update:** When PATCHing an existing record by SF record ID, remove `ohfy__Item__r` and `ohfy__Location__r` from the body. These are master-detail (create-only) fields. Including them returns `INVALID_FIELD_FOR_INSERT_UPDATE`.
+
+### Master-detail fields
+
+`ohfy__Item__c` and `ohfy__Location__c` are master-detail relationships:
+- **Create:** Set via `__r` relationship syntax (e.g., `ohfy__Item__r: { ohfy__VIP_External_ID__c: 'ITM:xxx' }`)
+- **Update:** Read-only. Strip from PATCH body. The record stays parented to the original Item and Location.
+
+### Writable vs formula fields
+
+| Field | Writable | Notes |
+|-------|----------|-------|
+| `ohfy__Quantity_On_Hand__c` | Yes | Case quantity — use this for integration |
+| `Cases_On_Hand__c` | No | Formula/rollup |
+| `Units_On_Hand__c` | No | Formula/rollup |
+| `ohfy__Is_Active__c` | Yes | Active flag |
+
+## Discovered in
+
+- VIP SRS E2E validation (2026-04-13): 264 pre-existing records in ROS2 sandbox blocked all VIP inventory inserts. Fixed with three-layer pre-query pattern.

--- a/knowledge-base/ohanafy/objects/item.md
+++ b/knowledge-base/ohanafy/objects/item.md
@@ -1,0 +1,53 @@
+# ohfy__Item__c
+
+Product master record. Represents individual SKUs (items) in the Ohanafy catalog with full product attributes, pricing, and classification data.
+
+## Quick facts
+
+- **Namespace:** ohfy__
+- **Field count:** 135+ — never use `SELECT *` in SOQL queries
+- **Triggers:** 9 trigger actions (TA_Item_* classes)
+- **Parent lookups:** Item_Line__c, Item_Type__c
+
+## Record type gating
+
+`ohfy__Packaging_Type__c` is a dependent picklist that accepts different values per record type. This has critical integration implications:
+
+- **Integration user must have "Finished Good" record type assigned** on their profile
+- **Composite API body must include `RecordTypeId`** — without it, the default Master record type is used, which rejects valid Finished Good picklist values
+- Record type can be looked up dynamically: `SELECT Id FROM RecordType WHERE SObjectType = 'ohfy__Item__c' AND DeveloperName = 'Finished_Good'`
+
+## Load order
+
+Items depend on parent records being loaded first:
+
+```
+1. Item_Line__c (product line/brand) — no upsert key, creates only
+2. Item_Type__c (product type/category)
+3. Item__c (references Item_Line__r and Item_Type__r)
+```
+
+### Item_Line__c has no upsert key
+
+`ohfy__Item_Line__c` records are created via `sf data create record` — there is no external ID field for upsert. **Re-runs create duplicates.** For production pipelines, add a pre-check query or dedup step.
+
+## Restricted picklists
+
+These fields require exact org values — always `sf sobject describe` before building crosswalks:
+
+| Field | Example values | Notes |
+|-------|---------------|-------|
+| `ohfy__Packaging_Type__c` | `Each`, `Case`, `Keg` | Dependent on UOM__c, gated by record type |
+| `ohfy__UOM__c` | `US Count` | Controls which Packaging_Type values are available |
+| `ohfy__Type__c` | `Finished Good` | Required for Depletion__c Item lookup filter |
+
+## External ID patterns
+
+External ID field names vary by integration:
+- VIP SRS: `ohfy__VIP_External_ID__c` (managed, on Item__c)
+- Other integrations may use different fields — check per-object metadata
+
+## Discovered in
+
+- VIP SRS Phase 1 (2026-04-09): Packaging_Type dependent picklist discovered during E2E
+- VIP SRS Phase 5c (2026-04-10): Finished Good RT + 5 prerequisites required for Depletion Item filter

--- a/knowledge-base/ohanafy/objects/placement.md
+++ b/knowledge-base/ohanafy/objects/placement.md
@@ -1,0 +1,53 @@
+# ohfy__Placement__c
+
+Account-by-Item tracking object. One record per Account+Item combination, aggregated from transaction data. Used for new placement detection, reorder alerts, and volume tracking.
+
+## Quick facts
+
+- **Namespace:** ohfy__
+- **Field count:** 59+ (managed)
+- **Key relationships:** Master-detail to Account, Master-detail to Item__c
+- **NOT custom:** This is a managed package object, not ohfy__Account_Item__c (which exists in source-index but has 0 deployed fields)
+
+## Master-detail fields (create-only)
+
+`ohfy__Account__c` and `ohfy__Item__c` are master-detail and can only be set on initial create (updateable=false):
+- **Create:** Use `__r` relationship syntax in Composite API body
+- **Update:** API silently ignores these fields — the record stays parented to the original Account and Item
+- **External ID pattern:** `PLC:{DistId}:{AcctNbr}:{SuppItem}` — one per Account+Item, not per transaction
+
+## Key input fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ohfy__Is_New_Placement__c` | Checkbox | Set `true` on every upsert (placement has recent activity) |
+| `ohfy__Lost_Placement_After_Days__c` | Number | Reorder alert threshold in days (e.g., 60) |
+| `ohfy__First_Sold_Date__c` | Date | Earliest sale date for this Account+Item |
+| `ohfy__Last_Sold_Date__c` | Date | Most recent sale date |
+| `ohfy__Last_Purchase_Date__c` | Date | Most recent purchase date |
+| `ohfy__Last_Purchase_Quantity__c` | Number | Quantity on most recent purchase |
+| `ohfy__Last_Invoice_Price__c` | Currency | Price on most recent invoice |
+| `ohfy__Is_Active__c` | Checkbox | Active placement flag |
+
+## Formula fields (auto-computed)
+
+These do NOT need to be set by the integration — they compute automatically:
+
+| Field | Formula | Notes |
+|-------|---------|-------|
+| `ohfy__Days_Since_Last_Order__c` | `TODAY() - Last_Sold_Date__c` | Days since last activity |
+| `ohfy__Lost_Placement_Date__c` | `Last_Sold_Date__c + Lost_Placement_After_Days__c` | Date after which placement is "lost" |
+| `ohfy__Item_Subtype__c` | `TEXT(Item__r.Package_Type__c)` | Derived from parent Item |
+
+## Volume fields (skip for daily pipeline)
+
+`All_Time_Volume__c`, `Weekly_Sales__c`, `Last_7_Days_Volume__c`, `Last_14_Days_Volume__c`, `Last_30_Days_Volume__c`, `Last_90_Days_Volume__c`, `Last_180_Days_Volume__c` are all updateable but require cumulative rollups across multiple file runs. Better handled by a scheduled Salesforce flow against Depletion__c records, not the daily integration pipeline.
+
+## Placement__c vs Account_Item__c
+
+`ohfy__Account_Item__c` exists in the managed package source-index with similar fields but has 0 deployed fields in the ROS2 sandbox. `ohfy__Placement__c` IS the right object for account-by-item tracking — it has the full field set for CSO features (new placement detection, reorder alerts, volume tracking windows).
+
+## Discovered in
+
+- VIP SRS Phase 5c (2026-04-10): Built placement integration from SLSDA invoice lines
+- VIP SRS Phase 5e (2026-04-13): Added Is_New_Placement + Lost_Placement_After_Days, verified formula fields auto-compute


### PR DESCRIPTION
## Summary

- **Placement enhancements:** `Is_New_Placement__c = true` + `Lost_Placement_After_Days__c = 60` in Script 07b. Feeds formula fields for 60-day reorder alerts (Days_Since_Last_Order, Lost_Placement_Date).
- **Account distributor rep codes:** Deployed `VIP_Salesman1__c` + `VIP_Salesman2__c` (Text(8)) on Account. Mapped in Script 05 from OUTDA Salesman1/2, filtering `999`/`HOUSE`. These are distributor rep codes (ROSM1/ROSM2), not supplier reps.
- **Inventory "Duplicate Record Blocked" fix:** Three-layer pre-query pattern in e2e-sandbox-runner.js + Script 06: (1) lazy timing after Phase 1, (2) batch-stamp VIP_External_ID__c on all 264 existing records, (3) strip master-detail fields from PATCH body.
- **5 new Ohanafy platform object docs** (Account, Depletion, Inventory, Item, Placement) covering integration constraints for any future integration loading these objects.
- **Updated integration-points.md** with managed package data loading constraints section.

## E2E Results (ROS2 sandbox, 2026-04-13)

| Phase | Records | Status |
|-------|---------|--------|
| 3 (Inventory) | 264 stamped + 12 inv + 485 history + 5 adj | ✅ 0 failures |
| 4 (Transactions) | 40 dep + 40 plc + 23 alc | ✅ 0 failures |
| **Total** | **612** | **0 failures** |

## Test plan

- [x] E2E pipeline validated against ROS2 sandbox (612 records, 0 failures)
- [x] Placement formula fields verified via SOQL (Days_Since_Last_Order=10, Lost_Placement_Date=2026-06-02)
- [x] Account VIP_Salesman1__c populated (B1, B4, 681, etc.)
- [x] Inventory pre-query stamps all 264 existing records before loading children
- [ ] Verify no script changes break existing unit tests (`node tests/test-runner.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)