### PR TITLE
fix(vip-srs): prevent Item_Line/Item_Type duplicates

### DIFF
--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/ohfy__Item_Line__c/fields/VIP_External_ID__c.field-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/ohfy__Item_Line__c/fields/VIP_External_ID__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/09/metadata">
+    <fullName>VIP_External_ID__c</fullName>
+    <externalId>true</externalId>
+    <label>VIP External ID</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>true</unique>
+</CustomField>

--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/ohfy__Item_Line__c/fields/VIP_File_Date__c.field-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/ohfy__Item_Line__c/fields/VIP_File_Date__c.field-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/09/metadata">
+    <fullName>VIP_File_Date__c</fullName>
+    <externalId>false</externalId>
+    <label>VIP File Date</label>
+    <required>false</required>
+    <type>Date</type>
+</CustomField>

--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/ohfy__Item_Type__c/fields/VIP_External_ID__c.field-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/ohfy__Item_Type__c/fields/VIP_External_ID__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/09/metadata">
+    <fullName>VIP_External_ID__c</fullName>
+    <externalId>true</externalId>
+    <label>VIP External ID</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>true</unique>
+</CustomField>

--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/ohfy__Item_Type__c/fields/VIP_File_Date__c.field-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/objects/ohfy__Item_Type__c/fields/VIP_File_Date__c.field-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/09/metadata">
+    <fullName>VIP_File_Date__c</fullName>
+    <externalId>false</externalId>
+    <label>VIP File Date</label>
+    <required>false</required>
+    <type>Date</type>
+</CustomField>

--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/permissionsets/VIP_SRS_Integration.permissionset-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/permissionsets/VIP_SRS_Integration.permissionset-meta.xml
@@ -120,6 +120,26 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>ohfy__Item_Line__c.VIP_External_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>ohfy__Item_Line__c.VIP_File_Date__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>ohfy__Item_Type__c.VIP_External_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>ohfy__Item_Type__c.VIP_File_Date__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Contact.External_ID__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/customers/shipyard-ros2/deploy-v2/force-app/main/default/profiles/Admin.profile-meta.xml
+++ b/customers/shipyard-ros2/deploy-v2/force-app/main/default/profiles/Admin.profile-meta.xml
@@ -117,6 +117,26 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>ohfy__Item_Line__c.VIP_External_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>ohfy__Item_Line__c.VIP_File_Date__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>ohfy__Item_Type__c.VIP_External_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>ohfy__Item_Type__c.VIP_File_Date__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Contact.External_ID__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/integrations/vip-srs/README.md
+++ b/integrations/vip-srs/README.md
@@ -82,6 +82,8 @@ Keys use only immutable business identifiers. Colon-delimited, prefixed, determi
 | Account (Outlet) | ACT | `ACT:FL01:00015` |
 | Contact | CON | `CON:FL01:00015` |
 | Item__c | ITM | `ITM:102312102` |
+| Item_Line__c | ILN | `ILN:Original Vodka` |
+| Item_Type__c | ITY | `ITY:Vodka` |
 | Location__c | LOC | `LOC:FL01` |
 | Depletion__c | DEP | `DEP:FL01:0699528:21159:102312102:C` |
 | Inventory__c | IVT | `IVT:FL01:102312102` |

--- a/integrations/vip-srs/ROADMAP.md
+++ b/integrations/vip-srs/ROADMAP.md
@@ -103,6 +103,15 @@
 - [x] Script 09 (cleanup): Added `countQuery` (SELECT COUNT()) per target for sanity check — Tray workflow should compare stale count vs upsert count before deleting; if stale > upserted, skip delete (possible truncated/partial file)
 - [x] **Key decision documented:** Invoice__c/Invoice_Item__c is NOT built from VIP data. VIP SLSDA = distributor→retailer depletions (Depletion__c + Placement__c). Invoice objects are for supplier→distributor invoicing — a separate data source entirely.
 
+### Phase 5e: Item_Line / Item_Type Duplicate Fix (2026-04-13)
+- [x] Root cause: Script 02 used Name-only creates with no external ID — re-runs without Tray lookup maps created duplicates
+- [x] Added `VIP_External_ID__c` (Text 255, unique, external ID) + `VIP_File_Date__c` (Date) to both `Item_Line__c` and `Item_Type__c`
+- [x] External ID formats: `ILN:{BrandDesc}` for Item_Line, `ITY:{GenericCat3}` for Item_Type
+- [x] Script 02: replaced Name-only create with Composite API PATCH upsert by external ID (same pattern as Item__c)
+- [x] Script 09: added Item_Line__c and Item_Type__c to cleanup targets with `perDistributor: false` flag (global reference data, not scoped by distributor)
+- [x] Updated permset + Admin profile FLS for 4 new fields
+- [x] Added `ITEM_LINE: 'ILN'` and `ITEM_TYPE: 'ITY'` prefixes to shared/constants.js + external-ids.js
+
 ## Next Up
 
 ### Phase 6: Tray.io Project Build
@@ -161,4 +170,5 @@
 12. **SRSCHAIN records are chain banners** even if names seem small (e.g., "Horizon Market"). They're parent accounts that OUTDA outlets link to via `Chain_Banner__r`. The detail (address, market, etc.) lives on the outlets, not the chains.
 13. **AccountSource 'VIP SRS' not in picklist:** The field is not restricted so the API accepts it, but the value won't appear in picklist dropdowns until added via Setup.
 14. **Item lookup filter chain on Depletion__c.Item__c:** The lookup filter (`optionalFilter: false`) requires the Item to have: (a) Finished Good record type, (b) `Type__c = 'Finished Good'`, (c) `UOM__c` set (e.g., 'US Count'), (d) `Packaging_Type__c` set (dependent on UOM, e.g., 'Each'), and (e) a `Transformation_Setting__c` record linking the Packaging_Type to a Volume UOM (e.g., Each → Fluid Ounce(s)). Missing any of these causes `FIELD_FILTER_VALIDATION_EXCEPTION`. Script 02 must ensure items meet all prerequisites before depletions can load.
-15. **Placement__c master-detail fields are create-only:** `ohfy__Account__c` and `ohfy__Item__c` are master-detail and can only be set on initial create (updateable=false). Use `__r` relationship syntax in Composite API body. On subsequent upserts, the API silently ignores these fields — the record stays parented to the original Account×Item.
+15. **Item_Line__c and Item_Type__c need external IDs for upsert:** These lookup objects use `VIP_External_ID__c` with formats `ILN:{BrandDesc}` and `ITY:{GenericCat3}`. Without external IDs, re-running Script 02 creates duplicates. The Tray workflow should still pre-query and pass `existingItemLines`/`existingItemTypes` maps for efficiency, but the upsert provides a safety net.
+16. **Placement__c master-detail fields are create-only:** `ohfy__Account__c` and `ohfy__Item__c` are master-detail and can only be set on initial create (updateable=false). Use `__r` relationship syntax in Composite API body. On subsequent upserts, the API silently ignores these fields — the record stays parented to the original Account×Item.

--- a/integrations/vip-srs/docs/VIP_AGENT_HANDOFF.md
+++ b/integrations/vip-srs/docs/VIP_AGENT_HANDOFF.md
@@ -355,7 +355,7 @@ VIP delivers 9 gzipped CSV files per business day. Filename format: `{TYPE}.N{YY
 | AlcoholPct | `40.0` | -- | Not mapped | No standard field; custom if needed |
 | PackageCode | `102312102` | -- | Not mapped | |
 | BrandCode | `11083076` | -- | Not mapped | Use BrandDesc instead |
-| BrandDesc | `Original Vodka` | Item_Line__c (lookup) | Lookup/create by name | Create Item_Line if missing |
+| BrandDesc | `Original Vodka` | Item_Line__c (lookup) | Upsert by `ILN:{BrandDesc}` | External ID: `VIP_External_ID__c` |
 | GeoCode | `` | -- | Not mapped | Always empty |
 | PackageType | `BTL` | Item__c.`Package_Type__c` | `BTL` -> `Packaged` | |
 | PackageSize | `SNGL 1L` | Item__c.`Packaging_Type__c` | Direct | |
@@ -365,7 +365,7 @@ VIP delivers 9 gzipped CSV files per business day. Filename format: `{TYPE}.N{YY
 | ContainerType | `S` | Item__c.`Type__c` | `S` -> `Finished Good` | See SRSVALUE ITCTYP |
 | TerritoryPtr | `01` | -- | Not mapped | |
 | GenericCat1-2 | `` | -- | Not mapped | |
-| GenericCat3 | `Vodka` | Item_Type__c (lookup) | Lookup/create by name | Create Item_Type if missing |
+| GenericCat3 | `Vodka` | Item_Type__c (lookup) | Upsert by `ITY:{GenericCat3}` | External ID: `VIP_External_ID__c` |
 | GenericCat4-6 | `` | -- | Not mapped | |
 | ExtOZpCase | `202.884` | -- | Not mapped | |
 | ExtMLpCase | `6000.000` | -- | Not mapped | Reference only |

--- a/integrations/vip-srs/scripts/02-itm2da-items.js
+++ b/integrations/vip-srs/scripts/02-itm2da-items.js
@@ -17,7 +17,7 @@
 // INLINE SHARED (for Tray Script connector — no require())
 // =============================================================================
 
-var PREFIX = { ITEM: 'ITM' };
+var PREFIX = { ITEM: 'ITM', ITEM_LINE: 'ILN', ITEM_TYPE: 'ITY' };
 var SF_CONFIG = { apiVersion: 'v62.0', batchSize: 25, namespacePrefix: 'ohfy' };
 
 var CONTAINER_TYPE = {
@@ -32,6 +32,8 @@ var VOLUME_UOM = { 'ML': 'Metric Volume', 'LTR': 'Metric Volume', 'OZ': 'US Volu
 var ML_TO_FLOZ = 0.033814;
 
 function itemKey(supplierItem) { return PREFIX.ITEM + ':' + supplierItem; }
+function itemLineKey(name) { return PREFIX.ITEM_LINE + ':' + name; }
+function itemTypeKey(name) { return PREFIX.ITEM_TYPE + ':' + name; }
 
 function clean(v) { if (v === undefined || v === null) return ''; return String(v).trim(); }
 function isBlankOrZeros(v) { if (!v) return true; var t = String(v).trim(); return t === '' || /^0+$/.test(t); }
@@ -65,7 +67,9 @@ var CONFIG = {
   itemSobject: NS + 'Item__c',
   itemExternalIdField: NS + 'VIP_External_ID__c',
   itemLineSobject: NS + 'Item_Line__c',
-  itemTypeSobject: NS + 'Item_Type__c'
+  itemLineExternalIdField: 'VIP_External_ID__c',
+  itemTypeSobject: NS + 'Item_Type__c',
+  itemTypeExternalIdField: 'VIP_External_ID__c'
 };
 
 // =============================================================================
@@ -153,6 +157,9 @@ exports.step = function(input) {
   // Finished Good record type ID (required for dependent picklist validation)
   var finishedGoodRtId = input.finishedGoodRecordTypeId || null;
 
+  // File date for VIP_File_Date__c (date of pipeline run, not from file contents)
+  var fileDate = input.fileDate || null;
+
   // Collect existing Item_Line and Item_Type lookups if provided
   var existingItemLines = input.existingItemLines || {};   // { name: sfId }
   var existingItemTypes = input.existingItemTypes || {};    // { name: sfId }
@@ -196,18 +203,54 @@ exports.step = function(input) {
     if (genericCat3) itemTypeNames[genericCat3] = true;
   });
 
-  // Build Item_Line__c records (create-if-missing approach)
-  var newItemLines = Object.keys(itemLineNames).filter(function(name) {
-    return !existingItemLines[name];
-  }).map(function(name) {
-    return { Name: name };
+  // Build Item_Line__c upsert records (Composite API PATCH by external ID)
+  var itemLineRecords = Object.keys(itemLineNames).map(function(name) {
+    var record = { Name: name, VIP_External_ID__c: itemLineKey(name) };
+    if (fileDate) record.VIP_File_Date__c = fileDate;
+    return record;
   });
 
-  // Build Item_Type__c records (create-if-missing approach)
-  var newItemTypes = Object.keys(itemTypeNames).filter(function(name) {
-    return !existingItemTypes[name];
-  }).map(function(name) {
-    return { Name: name };
+  var itemLineChunks = chunkArray(itemLineRecords);
+  var itemLineBatches = itemLineChunks.map(function(chunk) {
+    return {
+      compositeRequest: chunk.map(function(record, idx) {
+        var extId = record.VIP_External_ID__c;
+        var body = { Name: record.Name };
+        if (record.VIP_File_Date__c) body.VIP_File_Date__c = record.VIP_File_Date__c;
+        return {
+          method: 'PATCH',
+          url: '/services/data/' + SF_CONFIG.apiVersion + '/sobjects/' +
+            CONFIG.itemLineSobject + '/' + CONFIG.itemLineExternalIdField + '/' + sanitizeForUrl(extId),
+          referenceId: 'itemLine_' + idx,
+          body: body
+        };
+      })
+    };
+  });
+
+  // Build Item_Type__c upsert records (Composite API PATCH by external ID)
+  var itemTypeRecords = Object.keys(itemTypeNames).map(function(name) {
+    var record = { Name: name, VIP_External_ID__c: itemTypeKey(name) };
+    if (fileDate) record.VIP_File_Date__c = fileDate;
+    return record;
+  });
+
+  var itemTypeChunks = chunkArray(itemTypeRecords);
+  var itemTypeBatches = itemTypeChunks.map(function(chunk) {
+    return {
+      compositeRequest: chunk.map(function(record, idx) {
+        var extId = record.VIP_External_ID__c;
+        var body = { Name: record.Name };
+        if (record.VIP_File_Date__c) body.VIP_File_Date__c = record.VIP_File_Date__c;
+        return {
+          method: 'PATCH',
+          url: '/services/data/' + SF_CONFIG.apiVersion + '/sobjects/' +
+            CONFIG.itemTypeSobject + '/' + CONFIG.itemTypeExternalIdField + '/' + sanitizeForUrl(extId),
+          referenceId: 'itemType_' + idx,
+          body: body
+        };
+      })
+    };
   });
 
   // 3. TRANSFORM Item__c records
@@ -262,11 +305,13 @@ exports.step = function(input) {
 
   // 5. OUTPUT
   return {
-    // Item_Line and Item_Type records to create (processed before items)
-    newItemLines: newItemLines,
-    newItemLineCount: newItemLines.length,
-    newItemTypes: newItemTypes,
-    newItemTypeCount: newItemTypes.length,
+    // Item_Line and Item_Type upsert batches (Composite API, processed before items)
+    itemLineBatches: itemLineBatches,
+    itemLineBatchCount: itemLineBatches.length,
+    itemLineRecordCount: itemLineRecords.length,
+    itemTypeBatches: itemTypeBatches,
+    itemTypeBatchCount: itemTypeBatches.length,
+    itemTypeRecordCount: itemTypeRecords.length,
     // Item batches
     batches: itemBatches,
     batchCount: itemBatches.length,
@@ -287,8 +332,8 @@ exports.step = function(input) {
       invalid: invalid.length,
       skipped: skipped.length,
       transformErrors: transformErrors.length,
-      newItemLines: newItemLines.length,
-      newItemTypes: newItemTypes.length,
+      itemLines: itemLineRecords.length,
+      itemTypes: itemTypeRecords.length,
       batches: itemBatches.length,
       timestamp: new Date().toISOString()
     }

--- a/integrations/vip-srs/scripts/09-cleanup-stale.js
+++ b/integrations/vip-srs/scripts/09-cleanup-stale.js
@@ -25,6 +25,26 @@ var NS = SF_CONFIG.namespacePrefix + '__';
 
 var CLEANUP_TARGETS = [
   {
+    sobject: NS + 'Item_Line__c',
+    externalIdField: 'VIP_External_ID__c',
+    prefix: 'ILN',
+    fileDateField: 'VIP_File_Date__c',
+    fromDateField: null,
+    toDateField: null,
+    // Reference data — global to the org, not per-distributor
+    perDistributor: false
+  },
+  {
+    sobject: NS + 'Item_Type__c',
+    externalIdField: 'VIP_External_ID__c',
+    prefix: 'ITY',
+    fileDateField: 'VIP_File_Date__c',
+    fromDateField: null,
+    toDateField: null,
+    // Reference data — global to the org, not per-distributor
+    perDistributor: false
+  },
+  {
     sobject: NS + 'Depletion__c',
     externalIdField: 'VIP_External_ID__c',
     prefix: 'DEP',
@@ -79,7 +99,12 @@ function buildStaleQuery(target, distId, currentFileDate, fromDate, toDate) {
     sql += ' AND ' + target.fromDateField + ' >= ' + fromDate +
       ' AND ' + target.toDateField + ' <= ' + toDate;
   }
-  sql += " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+  // Global reference data (Item_Line, Item_Type) — filter by prefix only, not per-distributor
+  if (target.perDistributor === false) {
+    sql += " AND " + target.externalIdField + " LIKE '" + target.prefix + ":%'";
+  } else {
+    sql += " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+  }
   return sql;
 }
 
@@ -90,7 +115,11 @@ function buildCountQuery(target, distId, currentFileDate, fromDate, toDate) {
     sql += ' AND ' + target.fromDateField + ' >= ' + fromDate +
       ' AND ' + target.toDateField + ' <= ' + toDate;
   }
-  sql += " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+  if (target.perDistributor === false) {
+    sql += " AND " + target.externalIdField + " LIKE '" + target.prefix + ":%'";
+  } else {
+    sql += " AND " + target.externalIdField + " LIKE '" + target.prefix + ':' + distId + ":%'";
+  }
   return sql;
 }
 

--- a/integrations/vip-srs/scripts/e2e-sandbox-runner.js
+++ b/integrations/vip-srs/scripts/e2e-sandbox-runner.js
@@ -254,19 +254,13 @@ var PIPELINE = [
     script: '02-itm2da-items.js',
     fixture: 'itm2da-sample.csv',
     run: function(result) {
-      // Create Item_Lines first
-      if (result.newItemLines && result.newItemLines.length > 0) {
-        console.log('  Creating ' + result.newItemLines.length + ' Item Lines...');
-        result.newItemLines.forEach(function(il) {
-          createRecordByName('ohfy__Item_Line__c', il.Name);
-        });
+      // Upsert Item_Lines by external ID (ILN:{BrandDesc})
+      if (result.itemLineBatches && result.itemLineBatches.length > 0) {
+        sendBatches(result.itemLineBatches, 'Item Lines');
       }
-      // Create Item_Types
-      if (result.newItemTypes && result.newItemTypes.length > 0) {
-        console.log('  Creating ' + result.newItemTypes.length + ' Item Types...');
-        result.newItemTypes.forEach(function(it) {
-          createRecordByName('ohfy__Item_Type__c', it.Name);
-        });
+      // Upsert Item_Types by external ID (ITY:{GenericCat3})
+      if (result.itemTypeBatches && result.itemTypeBatches.length > 0) {
+        sendBatches(result.itemTypeBatches, 'Item Types');
       }
       // Upsert Items
       return sendBatches(result.batches, 'Items');

--- a/integrations/vip-srs/shared/constants.js
+++ b/integrations/vip-srs/shared/constants.js
@@ -21,7 +21,9 @@ var PREFIX = {
   INVENTORY_HISTORY: 'IVH',
   INVENTORY_ADJUSTMENT: 'IVA',
   ALLOCATION: 'ALC',
-  PLACEMENT: 'PLC'
+  PLACEMENT: 'PLC',
+  ITEM_LINE: 'ILN',
+  ITEM_TYPE: 'ITY'
 };
 
 // =============================================================================

--- a/integrations/vip-srs/shared/external-ids.js
+++ b/integrations/vip-srs/shared/external-ids.js
@@ -120,6 +120,22 @@ function allocationKey(distId, supplierItem, controlDate, uom) {
 }
 
 /**
+ * Item_Line__c: ILN:{BrandDesc}
+ * @param {string} name - Brand description (BrandDesc from ITM2DA)
+ */
+function itemLineKey(name) {
+  return PREFIX.ITEM_LINE + ':' + name;
+}
+
+/**
+ * Item_Type__c: ITY:{GenericCat3}
+ * @param {string} name - Category name (GenericCat3 from ITM2DA)
+ */
+function itemTypeKey(name) {
+  return PREFIX.ITEM_TYPE + ':' + name;
+}
+
+/**
  * Placement__c: PLC:{DistId}:{AcctNbr}:{SuppItem}
  * One per Account×Item pair — aggregated from SLSDA invoice lines.
  * @param {string} distId - Distributor code
@@ -140,6 +156,8 @@ if (typeof module !== 'undefined' && module.exports) {
     accountKey: accountKey,
     contactKey: contactKey,
     itemKey: itemKey,
+    itemLineKey: itemLineKey,
+    itemTypeKey: itemTypeKey,
     locationKey: locationKey,
     invoiceKey: invoiceKey,
     invoiceLineKey: invoiceLineKey,

--- a/integrations/vip-srs/tests/test-runner.js
+++ b/integrations/vip-srs/tests/test-runner.js
@@ -157,14 +157,18 @@ if (result.errors && result.errors.length > 0) {
   console.log('');
 }
 
-// Extra outputs (for ITM2DA)
-if (result.newItemLines) {
-  console.log('New Item Lines:', result.newItemLineCount);
-  result.newItemLines.slice(0, 5).forEach(function(il) { console.log('  -', il.Name); });
+// Extra outputs (for ITM2DA — Item_Line/Item_Type upsert batches)
+if (result.itemLineBatches && result.itemLineBatches.length > 0) {
+  console.log('Item Line batches:', result.itemLineBatchCount, '(' + result.itemLineRecordCount + ' records)');
+  var firstIL = result.itemLineBatches[0].compositeRequest[0];
+  console.log('  First:', firstIL.method, firstIL.url);
+  console.log('  Body:', JSON.stringify(firstIL.body));
 }
-if (result.newItemTypes) {
-  console.log('New Item Types:', result.newItemTypeCount);
-  result.newItemTypes.slice(0, 5).forEach(function(it) { console.log('  -', it.Name); });
+if (result.itemTypeBatches && result.itemTypeBatches.length > 0) {
+  console.log('Item Type batches:', result.itemTypeBatchCount, '(' + result.itemTypeRecordCount + ' records)');
+  var firstIT = result.itemTypeBatches[0].compositeRequest[0];
+  console.log('  First:', firstIT.method, firstIT.url);
+  console.log('  Body:', JSON.stringify(firstIT.body));
 }
 
 // Assertions

--- a/skills/ohanafy/ohfy-core-expert/references/data-model/composite-request-order.md
+++ b/skills/ohanafy/ohfy-core-expert/references/data-model/composite-request-order.md
@@ -57,8 +57,8 @@ WRONG:
 
 ```
 1. Account (Customer) - PATCH via External_ID__c
-2. Item_Line__c (Brand) - PATCH via Mapping_Key__c
-3. Item_Type__c (Category) - PATCH via Mapping_Key__c
+2. Item_Line__c (Brand) - PATCH via Mapping_Key__c or VIP_External_ID__c
+3. Item_Type__c (Category) - PATCH via Mapping_Key__c or VIP_External_ID__c
 4. Item__c (Product) - PATCH via External_ID__c
 5. Order__c (Invoice) - PATCH via External_ID__c, reference Account
 6. Order_Item__c (Line Item) - PATCH via External_ID__c, reference Order__c and Item__c

--- a/skills/ohanafy/ohfy-core-expert/references/data-model/core-objects.md
+++ b/skills/ohanafy/ohfy-core-expert/references/data-model/core-objects.md
@@ -148,23 +148,28 @@ try {
 **API Name**: `ohfy__Item_Line__c`
 
 **Key External IDs**:
-- `Mapping_Key__c` - Legacy mapping identifier
+- `Mapping_Key__c` - General mapping identifier (ecommerce, GP Analytics)
+- `VIP_External_ID__c` - VIP SRS external ID (format: `ILN:{BrandDesc}`)
 
 **Critical Fields**:
 - `Name` - Brand/line name
 - `Active__c` - Boolean
 - `Vendor__c` - Vendor (lookup)
+- `VIP_File_Date__c` - Date of VIP pipeline run (for stale cleanup)
 
 **Integration Pattern**:
 ```javascript
-// Upsert via Mapping_Key__c
+// Upsert via Mapping_Key__c (general)
 {
     "method": "PATCH",
     "url": "/services/data/v62.0/sobjects/ohfy__Item_Line__c/ohfy__Mapping_Key__c/brand_abc",
-    "body": {
-        "Name": "ABC Brewery",
-        "ohfy__Active__c": true
-    }
+    "body": { "Name": "ABC Brewery", "ohfy__Active__c": true }
+}
+// Upsert via VIP_External_ID__c (VIP SRS)
+{
+    "method": "PATCH",
+    "url": "/services/data/v62.0/sobjects/ohfy__Item_Line__c/VIP_External_ID__c/ILN:Original%20Vodka",
+    "body": { "Name": "Original Vodka", "VIP_File_Date__c": "2026-04-13" }
 }
 ```
 
@@ -177,22 +182,27 @@ try {
 **API Name**: `ohfy__Item_Type__c`
 
 **Key External IDs**:
-- `Mapping_Key__c` - Legacy mapping identifier
+- `Mapping_Key__c` - General mapping identifier (ecommerce, GP Analytics)
+- `VIP_External_ID__c` - VIP SRS external ID (format: `ITY:{GenericCat3}`)
 
 **Critical Fields**:
 - `Name` - Type/category name
 - `Active__c` - Boolean
+- `VIP_File_Date__c` - Date of VIP pipeline run (for stale cleanup)
 
 **Integration Pattern**:
 ```javascript
-// Upsert via Mapping_Key__c
+// Upsert via Mapping_Key__c (general)
 {
     "method": "PATCH",
     "url": "/services/data/v62.0/sobjects/ohfy__Item_Type__c/ohfy__Mapping_Key__c/type_lager",
-    "body": {
-        "Name": "Lager",
-        "ohfy__Active__c": true
-    }
+    "body": { "Name": "Lager", "ohfy__Active__c": true }
+}
+// Upsert via VIP_External_ID__c (VIP SRS)
+{
+    "method": "PATCH",
+    "url": "/services/data/v62.0/sobjects/ohfy__Item_Type__c/VIP_External_ID__c/ITY:Vodka",
+    "body": { "Name": "Vodka", "VIP_File_Date__c": "2026-04-13" }
 }
 ```
 

--- a/skills/ohanafy/ohfy-core-expert/references/data-model/external-id-patterns.md
+++ b/skills/ohanafy/ohfy-core-expert/references/data-model/external-id-patterns.md
@@ -95,23 +95,33 @@ edi_UPC-012345678901   # EDI UPC code
 
 ### Item_Line__c (Brand)
 
-**Field**: `ohfy__Mapping_Key__c`
+**Fields**: `ohfy__Mapping_Key__c` (general), `VIP_External_ID__c` (VIP SRS)
 
 **Examples**:
 ```
+# Mapping_Key__c (ecommerce, GP Analytics)
 gpa_brand_abc          # GP Analytics brand
-ILN:Shipyard IPA       # VIP SRS product line (colon-delimited prefix)
 shopify_vendor_123     # Shopify vendor
+
+# VIP_External_ID__c (VIP SRS — colon-delimited prefix)
+ILN:Original Vodka     # ILN:{BrandDesc from ITM2DA}
 ```
 
-**Upsert**:
+**Upsert** (general):
 ```javascript
 {
     "method": "PATCH",
     "url": "/services/data/v62.0/sobjects/ohfy__Item_Line__c/ohfy__Mapping_Key__c/gpa_brand_abc",
-    "body": {
-        "Name": "ABC Brewery"
-    }
+    "body": { "Name": "ABC Brewery" }
+}
+```
+
+**Upsert** (VIP SRS):
+```javascript
+{
+    "method": "PATCH",
+    "url": "/services/data/v62.0/sobjects/ohfy__Item_Line__c/VIP_External_ID__c/ILN:Original%20Vodka",
+    "body": { "Name": "Original Vodka", "VIP_File_Date__c": "2026-04-13" }
 }
 ```
 
@@ -119,23 +129,34 @@ shopify_vendor_123     # Shopify vendor
 
 ### Item_Type__c (Category)
 
-**Field**: `ohfy__Mapping_Key__c`
+**Fields**: `ohfy__Mapping_Key__c` (general), `VIP_External_ID__c` (VIP SRS)
 
 **Examples**:
 ```
+# Mapping_Key__c (ecommerce, GP Analytics)
 gpa_type_lager         # GP Analytics type
 shopify_cat_beer       # Shopify category
 woo_cat_123            # WooCommerce category ID
+
+# VIP_External_ID__c (VIP SRS — colon-delimited prefix)
+ITY:Vodka              # ITY:{GenericCat3 from ITM2DA}
 ```
 
-**Upsert**:
+**Upsert** (general):
 ```javascript
 {
     "method": "PATCH",
     "url": "/services/data/v62.0/sobjects/ohfy__Item_Type__c/ohfy__Mapping_Key__c/gpa_type_lager",
-    "body": {
-        "Name": "Lager"
-    }
+    "body": { "Name": "Lager" }
+}
+```
+
+**Upsert** (VIP SRS):
+```javascript
+{
+    "method": "PATCH",
+    "url": "/services/data/v62.0/sobjects/ohfy__Item_Type__c/VIP_External_ID__c/ITY:Vodka",
+    "body": { "Name": "Vodka", "VIP_File_Date__c": "2026-04-13" }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Added `VIP_External_ID__c` + `VIP_File_Date__c` fields to `Item_Line__c` and `Item_Type__c` — Script 02 now upserts by external ID (`ILN:{BrandDesc}`, `ITY:{GenericCat3}`) instead of creating by Name, preventing duplicates on re-runs
- Added both objects to Script 09 stale cleanup targets with `perDistributor: false` flag (global reference data, not per-distributor)
- Updated ohfy-core-expert skill references, VIP README, handoff doc, and e2e runner to reflect the new external ID strategy
- Cleaned 15 duplicate records (12 Item_Lines + 3 Item_Types) from ROS2 sandbox

## Test plan
- [x] Script 02 test: 6/6 assertions pass, Item_Line/Item_Type batches use Composite API PATCH by external ID
- [x] Script 09 test: generates correct SOQL for Item_Line/Item_Type (no distId in LIKE clause, uses `ILN:%` / `ITY:%`)
- [ ] Deploy `deploy-v2/` to ROS2 sandbox to create the 4 new fields
- [ ] Run e2e-sandbox-runner.js to verify upsert idempotency (no dupes after multiple runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)