### PR TITLE
fix(vip-srs): wire Item_Line/Item_Type lookups and collapse 99Z placeholders

### DIFF
--- a/integrations/vip-srs/scripts/02-itm2da-items.js
+++ b/integrations/vip-srs/scripts/02-itm2da-items.js
@@ -168,6 +168,7 @@ exports.step = function(input) {
   var valid = [];
   var invalid = [];
   var skipped = [];
+  var seen99Z = false;
 
   rows.forEach(function(row, idx) {
     var recordType = clean(row.RecordId);
@@ -185,6 +186,20 @@ exports.step = function(input) {
     // Skip zero-volume placeholder
     if (supplierItem === 'XXXXXX') {
       skipped.push({ rowIndex: idx, reason: 'Zero-volume placeholder' });
+      return;
+    }
+
+    // Collapse 99Z generic volume placeholders into a single item
+    if (supplierItem.indexOf('99Z') === 0) {
+      if (!seen99Z) {
+        seen99Z = true;
+        var collapsed = {};
+        Object.keys(row).forEach(function(k) { collapsed[k] = row[k]; });
+        collapsed.SupplierItem = '99Z-GENERIC';
+        collapsed.Desc = 'Generic Volume (Unmapped)';
+        valid.push(collapsed);
+      }
+      skipped.push({ rowIndex: idx, reason: '99Z placeholder (collapsed)' });
       return;
     }
 

--- a/integrations/vip-srs/scripts/02-itm2da-items.js
+++ b/integrations/vip-srs/scripts/02-itm2da-items.js
@@ -261,16 +261,16 @@ exports.step = function(input) {
     try {
       var record = transformItem(row, finishedGoodRtId);
 
-      // Add Item_Line__c lookup reference (by name)
+      // Wire Item_Line__c lookup via external ID relationship reference
       var brandDesc = clean(row.BrandDesc);
       if (brandDesc) {
-        record._itemLineName = brandDesc;  // Used for post-processing lookup
+        record[NS + 'Item_Line__r'] = { VIP_External_ID__c: itemLineKey(brandDesc) };
       }
 
-      // Add Item_Type__c lookup reference (by name)
+      // Wire Item_Type__c lookup via external ID relationship reference
       var genericCat3 = clean(row.GenericCat3);
       if (genericCat3) {
-        record._itemTypeName = genericCat3;  // Used for post-processing lookup
+        record[NS + 'Item_Type__r'] = { VIP_External_ID__c: itemTypeKey(genericCat3) };
       }
 
       itemRecords.push(record);

--- a/integrations/vip-srs/scripts/02-itm2da-items.js
+++ b/integrations/vip-srs/scripts/02-itm2da-items.js
@@ -33,7 +33,7 @@ var ML_TO_FLOZ = 0.033814;
 
 function itemKey(supplierItem) { return PREFIX.ITEM + ':' + supplierItem; }
 function itemLineKey(name) { return PREFIX.ITEM_LINE + ':' + name; }
-function itemTypeKey(name) { return PREFIX.ITEM_TYPE + ':' + name; }
+function itemTypeKey(brandDesc, name) { return PREFIX.ITEM_TYPE + ':' + brandDesc + ':' + name; }
 
 function clean(v) { if (v === undefined || v === null) return ''; return String(v).trim(); }
 function isBlankOrZeros(v) { if (!v) return true; var t = String(v).trim(); return t === '' || /^0+$/.test(t); }
@@ -192,15 +192,20 @@ exports.step = function(input) {
   });
 
   // 2. EXTRACT unique Item_Line and Item_Type values
+  // Item_Type is scoped per Item_Line because the Item_Type lookup on Item__c
+  // has a dependent filter (optionalFilter: false) requiring
+  // Item_Type__r.Item_Line__c = Item__c.Item_Line__c.
   var itemLineNames = {};  // { brandDesc: true }
-  var itemTypeNames = {};  // { genericCat3: true }
+  var itemTypePairs = {};  // { 'brandDesc\tbrandDesc': genericCat3 }
 
   valid.forEach(function(row) {
     var brandDesc = clean(row.BrandDesc);
     if (brandDesc) itemLineNames[brandDesc] = true;
 
     var genericCat3 = clean(row.GenericCat3);
-    if (genericCat3) itemTypeNames[genericCat3] = true;
+    if (brandDesc && genericCat3) {
+      itemTypePairs[brandDesc + '\t' + genericCat3] = true;
+    }
   });
 
   // Build Item_Line__c upsert records (Composite API PATCH by external ID)
@@ -229,8 +234,16 @@ exports.step = function(input) {
   });
 
   // Build Item_Type__c upsert records (Composite API PATCH by external ID)
-  var itemTypeRecords = Object.keys(itemTypeNames).map(function(name) {
-    var record = { Name: name, VIP_External_ID__c: itemTypeKey(name) };
+  // Each Item_Type is scoped to an Item_Line via ohfy__Item_Line__r.
+  var itemTypeRecords = Object.keys(itemTypePairs).map(function(pairKey) {
+    var parts = pairKey.split('\t');
+    var brandDesc = parts[0];
+    var genericCat3 = parts[1];
+    var record = {
+      Name: genericCat3,
+      VIP_External_ID__c: itemTypeKey(brandDesc, genericCat3)
+    };
+    record[NS + 'Item_Line__r'] = { VIP_External_ID__c: itemLineKey(brandDesc) };
     if (fileDate) record.VIP_File_Date__c = fileDate;
     return record;
   });
@@ -241,6 +254,7 @@ exports.step = function(input) {
       compositeRequest: chunk.map(function(record, idx) {
         var extId = record.VIP_External_ID__c;
         var body = { Name: record.Name };
+        body[NS + 'Item_Line__r'] = record[NS + 'Item_Line__r'];
         if (record.VIP_File_Date__c) body.VIP_File_Date__c = record.VIP_File_Date__c;
         return {
           method: 'PATCH',
@@ -268,9 +282,10 @@ exports.step = function(input) {
       }
 
       // Wire Item_Type__c lookup via external ID relationship reference
+      // Uses compound key (brandDesc + genericCat3) to match the per-Item_Line scoping
       var genericCat3 = clean(row.GenericCat3);
-      if (genericCat3) {
-        record[NS + 'Item_Type__r'] = { VIP_External_ID__c: itemTypeKey(genericCat3) };
+      if (brandDesc && genericCat3) {
+        record[NS + 'Item_Type__r'] = { VIP_External_ID__c: itemTypeKey(brandDesc, genericCat3) };
       }
 
       itemRecords.push(record);
@@ -317,9 +332,9 @@ exports.step = function(input) {
     batchCount: itemBatches.length,
     records: itemRecords,
     recordCount: itemRecords.length,
-    // Lookup references (for wiring Item_Line/Item_Type IDs in a subsequent step)
+    // Lookup references
     itemLineNames: Object.keys(itemLineNames),
-    itemTypeNames: Object.keys(itemTypeNames),
+    itemTypePairs: Object.keys(itemTypePairs),
     // Errors
     errors: invalid.concat(transformErrors.map(function(e) {
       return { rowIndex: e.rowIndex, reason: 'Transform error: ' + e.error };

--- a/integrations/vip-srs/scripts/06-invda-inventory.js
+++ b/integrations/vip-srs/scripts/06-invda-inventory.js
@@ -89,11 +89,13 @@ var TRANS_CODE = {
 // =============================================================================
 
 function transformInventory(distId, supplierItem, casesOnHand, unitsOnHand) {
+  // Collapse 99Z generic volume placeholders to single item
+  var itemSuppItem = supplierItem.indexOf('99Z') === 0 ? '99Z-GENERIC' : supplierItem;
   var record = {};
   record.VIP_External_ID__c = inventoryKey(distId, supplierItem);
   // Item lookup (master-detail — set on create, ignored on update)
   record[NS + 'Item__r'] = {};
-  record[NS + 'Item__r'][NS + 'VIP_External_ID__c'] = itemKey(supplierItem);
+  record[NS + 'Item__r'][NS + 'VIP_External_ID__c'] = itemKey(itemSuppItem);
   // Location lookup via VIP_External_ID__c
   record[NS + 'Location__r'] = { VIP_External_ID__c: locationKey(distId) };
   // Quantity_On_Hand__c is the writable case quantity field
@@ -104,6 +106,8 @@ function transformInventory(distId, supplierItem, casesOnHand, unitsOnHand) {
 
 function transformHistory(row, distId, fileDate) {
   var supplierItem = clean(row.SupplierItem);
+  // Collapse 99Z generic volume placeholders to single item
+  var itemSuppItem = supplierItem.indexOf('99Z') === 0 ? '99Z-GENERIC' : supplierItem;
   var postingDate = clean(row.PostingDate);
   var uom = clean(row.UnitOfMeasure);
   var record = {};
@@ -112,7 +116,7 @@ function transformHistory(row, distId, fileDate) {
   record[NS + 'Stamped_Date__c'] = toSfDate(postingDate);
   // Item lookup (relationship syntax)
   record[NS + 'Item__r'] = {};
-  record[NS + 'Item__r'][NS + 'VIP_External_ID__c'] = itemKey(supplierItem);
+  record[NS + 'Item__r'][NS + 'VIP_External_ID__c'] = itemKey(itemSuppItem);
   record[NS + 'Quantity_On_Hand__c'] = toInt(row.Quantity);
   // Parent Inventory lookup (relationship syntax)
   record[NS + 'Inventory__r'] = { VIP_External_ID__c: inventoryKey(distId, supplierItem) };

--- a/integrations/vip-srs/scripts/07-slsda-depletions.js
+++ b/integrations/vip-srs/scripts/07-slsda-depletions.js
@@ -64,6 +64,8 @@ function transformDepletion(row, distId, fileDate) {
   var invoiceNbr = clean(row.InvoiceNbr);
   var acctNbr = clean(row.AcctNbr);
   var suppItem = clean(row.SuppItem);
+  // Collapse 99Z generic volume placeholders to single item
+  var itemSuppItem = suppItem.indexOf('99Z') === 0 ? '99Z-GENERIC' : suppItem;
   var uom = clean(row.UOM);
   var qty = toNumber(row.Qty);
   var invoiceDate = clean(row.InvoiceDate);
@@ -79,7 +81,7 @@ function transformDepletion(row, distId, fileDate) {
 
   // Item lookup (relationship syntax)
   record[NS + 'Item__r'] = {};
-  record[NS + 'Item__r'][NS + 'VIP_External_ID__c'] = itemKey(suppItem);
+  record[NS + 'Item__r'][NS + 'VIP_External_ID__c'] = itemKey(itemSuppItem);
 
   // Depletion type — org picklist has display types (Cold Box, Draft Line, etc.),
   // not transaction types. Skip for VIP sales data.

--- a/integrations/vip-srs/scripts/07b-slsda-placements.js
+++ b/integrations/vip-srs/scripts/07b-slsda-placements.js
@@ -122,8 +122,10 @@ function transformPlacement(entry) {
   // Master-detail lookups (create-only — Composite API ignores on update)
   record[NS + 'Account__r'] = { ohfy__External_ID__c: accountKey(entry.distId, entry.acctNbr) };
 
+  // Collapse 99Z generic volume placeholders to single item
+  var itemSuppItem = entry.suppItem.indexOf('99Z') === 0 ? '99Z-GENERIC' : entry.suppItem;
   var itemRef = {};
-  itemRef[NS + 'VIP_External_ID__c'] = itemKey(entry.suppItem);
+  itemRef[NS + 'VIP_External_ID__c'] = itemKey(itemSuppItem);
   record[NS + 'Item__r'] = itemRef;
 
   // Dates

--- a/integrations/vip-srs/shared/external-ids.js
+++ b/integrations/vip-srs/shared/external-ids.js
@@ -118,11 +118,14 @@ function itemLineKey(name) {
 }
 
 /**
- * Item_Type__c: ITY:{GenericCat3}
+ * Item_Type__c: ITY:{BrandDesc}:{GenericCat3}
+ * Scoped per Item_Line because the Item_Type lookup on Item__c has a
+ * dependent filter requiring Item_Type.Item_Line = Item.Item_Line.
+ * @param {string} brandDesc - Brand description (BrandDesc from ITM2DA)
  * @param {string} name - Category name (GenericCat3 from ITM2DA)
  */
-function itemTypeKey(name) {
-  return PREFIX.ITEM_TYPE + ':' + name;
+function itemTypeKey(brandDesc, name) {
+  return PREFIX.ITEM_TYPE + ':' + brandDesc + ':' + name;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Wire Item_Line/Item_Type lookups on Item__c** — Replaced internal `_itemLineName`/`_itemTypeName` markers with `__r` relationship references that resolve lookups by external ID in the Composite API upsert. Items now correctly populate their Item_Line and Item_Type fields.
- **Scope Item_Type per Item_Line** — Changed Item_Type external ID from `ITY:{GenericCat3}` to compound `ITY:{BrandDesc}:{GenericCat3}` and wired `ohfy__Item_Line__r` on each Item_Type record. This satisfies the dependent lookup filter (`optionalFilter: false`) on `Item__c.ohfy__Item_Type__c`.
- **Collapse 99Z generic volume placeholders** — 41 inactive 99Z* placeholder SKUs now collapse to a single `ITM:99Z-GENERIC` item ("Generic Volume (Unmapped)"). Depletions, placements, and inventory referencing 99Z items remap to this single record, keeping gap analysis while eliminating report/dashboard noise.

## Files changed

| File | Change |
|------|--------|
| `scripts/02-itm2da-items.js` | All 3 fixes: `__r` lookups, compound Item_Type key, 99Z collapse |
| `scripts/06-invda-inventory.js` | 99Z→99Z-GENERIC remap in inventory + history transforms |
| `scripts/07-slsda-depletions.js` | 99Z→99Z-GENERIC remap in depletion item lookup |
| `scripts/07b-slsda-placements.js` | 99Z→99Z-GENERIC remap in placement item lookup |
| `shared/external-ids.js` | `itemTypeKey()` now takes `(brandDesc, name)` for compound format |

## Test plan

- [x] `test-runner.js` passes all 6 assertions for Script 02
- [x] Item__c output includes `ohfy__Item_Line__r` and `ohfy__Item_Type__r` with external ID refs
- [x] Item_Type__c output includes `ohfy__Item_Line__r` wiring
- [x] Compound key format verified: `ITY:{BrandDesc}:{GenericCat3}`
- [ ] Re-run E2E against ROS2 sandbox (all VIP data purged, ready for clean reload)

## Context

After a VIP SRS data load, no Item__c records had Item_Line or Item_Type values. Root cause: the script used `_`-prefixed internal markers that were stripped by the Composite API body builder. The dependent lookup filter on Item_Type also required Item_Type records to be scoped per Item_Line. Additionally, 41 inactive 99Z placeholder items were cluttering reports and dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)