### PR TITLE
chore: resync 5 skill stubs after gstack 1.15.0.0 upgrade

### DIFF
--- a/skills/make-pdf/SKILL.md
+++ b/skills/make-pdf/SKILL.md
@@ -5,11 +5,9 @@ version: 1.0.0
 description: |
   Turn any markdown file into a publication-quality PDF. Proper 1in margins,
   intelligent page breaks, page numbers, cover pages, running headers, curly
-  quotes and em dashes, clickable TOC, diagonal DRAFT watermark. Output you'd
-  send to a VC partner, a book agent, a judge, or Rick Rubin's team. Not a
-  draft artifact — a finished artifact. Use when asked to "make a PDF",
-  "export to PDF", "turn this markdown into a PDF", or "generate a document".
-  (gstack)
+  quotes and em dashes, clickable TOC, diagonal DRAFT watermark. Not a draft
+  artifact — a finished artifact. Use when asked to "make a PDF", "export to
+  PDF", "turn this markdown into a PDF", or "generate a document". (gstack)
   Voice triggers (speech-to-text aliases): "make this a pdf", "make it a pdf", "export to pdf", "turn this into a pdf", "turn this markdown into a pdf", "generate a pdf", "make a pdf from", "pdf this markdown".
 triggers:
   - markdown to pdf

--- a/skills/plan-ceo-review/SKILL.md
+++ b/skills/plan-ceo-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: plan-ceo-review
 preamble-tier: 3
+interactive: true
 version: 1.0.0
 description: |
   CEO/founder-mode plan review. Rethink the problem, find the 10-star product,

--- a/skills/plan-design-review/SKILL.md
+++ b/skills/plan-design-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: plan-design-review
 preamble-tier: 3
+interactive: true
 version: 2.0.0
 description: |
   Designer's eye plan review — interactive, like CEO and Eng review.

--- a/skills/plan-devex-review/SKILL.md
+++ b/skills/plan-devex-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: plan-devex-review
 preamble-tier: 3
+interactive: true
 version: 2.0.0
 description: |
   Interactive developer experience plan review. Explores developer personas,

--- a/skills/plan-eng-review/SKILL.md
+++ b/skills/plan-eng-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: plan-eng-review
 preamble-tier: 3
+interactive: true
 version: 1.0.0
 description: |
   Eng manager-mode plan review. Lock in the execution plan — architecture,


### PR DESCRIPTION
## Summary
After gstack upgraded from 1.4.0.0 → 1.15.0.0 in #158, the post-pull symlink fixer regenerated 5 SKILL.md stubs from the new upstream source. Main's CI auto-fix-symlinks step only normalizes symlinks — it doesn't refresh stub frontmatter — so this catches up.

## Related Issues
Relates to #158

## Type of Change
- [x] CI/CD / Infrastructure

## Changes Made
- 4 plan-* stubs (`plan-ceo-review`, `plan-design-review`, `plan-devex-review`, `plan-eng-review`) gain the new `interactive: true` frontmatter field that gstack 1.15.0.0 emits
- `make-pdf` stub drops a tagline that upstream removed

## Testing
- [x] Manual testing performed (vendored gstack VERSION reads 1.15.0.0; `bash scripts/fix-gstack-symlinks.sh` is idempotent)

## Documentation
- [x] N/A - no doc changes needed

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] No new warnings introduced